### PR TITLE
Function to read umi_tools output

### DIFF
--- a/anndata/__init__.py
+++ b/anndata/__init__.py
@@ -45,6 +45,7 @@ Reading other file formats.
    read_loom
    read_mtx
    read_text
+   read_umi_tools
 
 
 Writing
@@ -67,7 +68,7 @@ Writing to other formats.
 """.format(main_narrative=AnnData._main_narrative)
 
 from .readwrite import read_loom, \
-    read_csv, read_excel, read_text, read_hdf, read_mtx
+    read_csv, read_excel, read_text, read_hdf, read_mtx, read_umi_tools
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/anndata/base.py
+++ b/anndata/base.py
@@ -709,6 +709,7 @@ class AnnData(IndexMixin):
         read_loom
         read_mtx
         read_text
+        read_umi_tools
 
         Notes
         -----

--- a/anndata/readwrite/read.py
+++ b/anndata/readwrite/read.py
@@ -86,7 +86,7 @@ def read_umi_tools(filename):
     
     df = DataFrame.from_dict(dod, orient = 'index') # build the matrix
     df.fillna(value = 0., inplace = True) # many NaN, replace with zeros
-    return AnnData(np.array(df), {'obs_names':df.index}, {'var_names':df.columns}
+    return AnnData(np.array(df), {'obs_names':df.index}, {'var_names':df.columns})
 
 
 def read_hdf(filename, key):

--- a/anndata/readwrite/read.py
+++ b/anndata/readwrite/read.py
@@ -55,6 +55,40 @@ def read_excel(filename, sheet):
     return AnnData(X, row, col)
 
 
+def read_umi_tools(filename):
+    """Read a gzipped condensed count matrix from umi_tools.
+
+    Parameters
+    ----------
+    filename : `str`
+        File name to read from.
+
+    Returns
+    -------
+    An :class:`~anndata.AnnData` object.
+    """
+    filename = str(filename)  # allow passing pathlib.Path objects
+    # import pandas for conversion of a dict of dicts into a matrix
+    # import gzip to read a gzipped file :-)
+    import gzip
+    from pandas import DataFrame
+    
+    dod = {} # this will contain basically everything
+    fh = gzip.open(filename)
+    header = fh.readline() # read the first line
+    
+    for line in fh:
+        t = line.decode('ascii').split('\t')  # gzip read bytes, hence the decoding
+        try:
+            dod[t[1]].update({t[0]:int(t[2])})
+        except KeyError:
+            dod[t[1]] = {t[0]:int(t[2])}
+    
+    df = DataFrame.from_dict(dod, orient = 'index') # build the matrix
+    df.fillna(value = 0., inplace = True) # many NaN, replace with zeros
+    return AnnData(np.array(df), {'obs_names':df.index}, {'var_names':df.columns}
+
+
 def read_hdf(filename, key):
     """Read `.h5` (hdf5) file.
 


### PR DESCRIPTION
`umi_tools` is a handy set of utilities to manage scRNA-seq experiments (among other thigs). The final results of a [typical single cell analysis](https://github.com/CGATOxford/UMI-tools/blob/master/doc/Single_cell_tutorial.md) is a condensed count matrix saved in a gzipped tab-separated file. This cannot be read with `read_mtx` function, probably due to a different header. 
I've written a quick function to import umi_tools datasets. If included in the main code, please add it also in the available possibilities in `scanpy.api.read` function