### PR TITLE
Update PyPI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
-|Docs| |PyPI| |Build Status| |Coverage|
+|PyPI| |Docs| |Build Status| |Coverage|
 
+.. |PyPI| image:: https://img.shields.io/pypi/v/anndata.svg
+   :target: https://pypi.org/project/anndata
 .. |Docs| image:: https://readthedocs.org/projects/anndata/badge/?version=latest
    :target: https://anndata.readthedocs.io
-.. |PyPI| image:: https://badge.fury.io/py/anndata.svg
-   :target: https://pypi.python.org/pypi/anndata
 .. |Build Status| image:: https://travis-ci.org/theislab/anndata.svg?branch=master
    :target: https://travis-ci.org/theislab/anndata
 .. |Coverage| image:: https://codecov.io/gh/theislab/anndata/branch/master/graph/badge.svg


### PR DESCRIPTION
The new one is smaller, because it doesn’t say “package”. It’s also orange which shows it’s not a build status and that it’s still a 0.X version