### PR TITLE
Fix pickling for BoundRecArrays

### DIFF
--- a/anndata/base.py
+++ b/anndata/base.py
@@ -84,6 +84,16 @@ class BoundRecArr(np.recarray):
         self._parent = getattr(obj, '_parent', None)
         self._attr = getattr(obj, '_attr', None)
 
+    def __reduce__(self):
+        pickled_state = super(self.__class__, self).__reduce__()
+        new_state = pickled_state[2] + (self.__dict__, )
+        return (pickled_state[0], pickled_state[1], new_state)
+    
+    def __setstate__(self, state):
+        for k, v in state[-1].items():
+            self.__setattr__(k, v)
+        super(self.__class__, self).__setstate__(state[0:-1])
+
     def copy(self, order='C'):
         new = super(BoundRecArr, self).copy()
         new._parent = self._parent

--- a/anndata/tests/base.py
+++ b/anndata/tests/base.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numpy import ma
 import pandas as pd
+import pickle
 from scipy import sparse as sp
 
 from anndata import AnnData
@@ -308,3 +309,8 @@ def test_rename_categories():
 
     assert list(adata.obs['cat_anno'].cat.categories) == new_categories
     assert list(adata.uns['tool']['cat_array'].dtype.names) == new_categories
+
+def test_pickle():
+    adata = AnnData()
+    adata2 = pickle.loads(pickle.dumps(adata))
+    assert adata2.obsm._parent == adata2

--- a/requires.txt
+++ b/requires.txt
@@ -1,4 +1,5 @@
 pandas>=0.21.0
+numpy>=1.14.0
 scipy
 h5py
 natsort


### PR DESCRIPTION
Fixes #27.

BoundRecArrays were losing their attributes when pickled. This can be fixed by overriding their `__reduce__` and `__setstate__` methods. I've basically just adopted a generalized version of [this stackoverflow answer](https://stackoverflow.com/a/26599346/3841270).

I had some trouble with the python 3.6 travis build, but fixed it by setting `numpy>=1.14.0` in the requirements. With a lower version of numpy, un-pickling a `BoundRecArray` throws the error:

```
ValueError: Invalid data-type size.
```