### PR TITLE
Add Zarr storage

### DIFF
--- a/anndata/__init__.py
+++ b/anndata/__init__.py
@@ -3,6 +3,7 @@ from .readwrite import (
     read_h5ad, read_loom, read_hdf,
     read_excel, read_umi_tools,
     read_csv, read_text, read_mtx,
+    read_zarr,
 )
 from .readwrite import read_h5ad as read  # backwards compat / shortcut for default format
 

--- a/anndata/base.py
+++ b/anndata/base.py
@@ -20,6 +20,7 @@ from scipy import sparse
 from scipy.sparse import issparse
 from scipy.sparse.sputils import IndexMixin
 from natsort import natsorted
+import zarr
 
 from . import h5py
 from . import utils
@@ -50,6 +51,7 @@ class StorageType(Enum):
     Array = np.ndarray
     Masked = ma.MaskedArray
     Sparse = sparse.spmatrix
+    Zarr = zarr.core.Array
 
     @classmethod
     def classes(cls):
@@ -782,6 +784,8 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
                 # TODO: maybe use view on data attribute of sparse matrix
                 #       as in readwrite.read_10x_h5
                 if X.dtype != np.dtype(dtype): X = X.astype(dtype)
+            elif isinstance(X, zarr.core.Array):
+                X = X.astype(dtype)
             else:  # is np.ndarray
                 X = X.astype(dtype, copy=False)
             # data matrix and shape

--- a/anndata/base.py
+++ b/anndata/base.py
@@ -1813,6 +1813,12 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
         from .readwrite.write import write_loom
         write_loom(filename, self)
 
+
+    def write_zarr(self, store, chunks):
+        from .readwrite.write import write_zarr
+        write_zarr(store, self, chunks=chunks)
+
+
     @staticmethod
     def _from_dict(ddata):
         """Allows to construct an instance of AnnData from a dictionary.

--- a/anndata/readwrite/read.py
+++ b/anndata/readwrite/read.py
@@ -340,7 +340,10 @@ def _read_key_value_from_zarr(f, d, key, key_write=None):
         return
     # the '()' means 'load everything into memory' (by contrast, ':'
     # only works if not reading a scalar type)
-    value = f[key][()]
+    if key != 'X':
+        value = f[key][()]
+    else:
+        value = f[key] # don't load X into memory
 
     def postprocess_reading(key, value):
         if value.ndim == 1 and len(value) == 1:

--- a/anndata/readwrite/read.py
+++ b/anndata/readwrite/read.py
@@ -321,6 +321,52 @@ def _read_text(
                    var={'var_names': col_names})
 
 
+def read_zarr(store):
+    import zarr
+    f = zarr.open(store, mode='r')
+    d = {}
+    for key in f.keys():
+        _read_key_value_from_zarr(f, d, key)
+    return AnnData(d)
+
+
+def _read_key_value_from_zarr(f, d, key, key_write=None):
+    import zarr
+    if key_write is None: key_write = key
+    if isinstance(f[key], zarr.hierarchy.Group):
+        d[key_write] = OrderedDict() if key == 'uns' else {}
+        for k in f[key].keys():
+            _read_key_value_from_zarr(f, d[key_write], key + '/' + k, k)
+        return
+    # the '()' means 'load everything into memory' (by contrast, ':'
+    # only works if not reading a scalar type)
+    value = f[key][()]
+
+    def postprocess_reading(key, value):
+        if value.ndim == 1 and len(value) == 1:
+            value = value[0]
+        if value.dtype.kind == 'S':
+            value = value.astype(str)
+            # backwards compat:
+            # recover a dictionary that has been stored as a string
+            if len(value) > 0:
+                if value[0] == '{' and value[-1] == '}': value = eval(value)
+        # transform byte strings in recarrays to unicode strings
+        # TODO: come up with a better way of solving this, see also below
+        if (key not in AnnData._H5_ALIASES['obs']
+                and key not in AnnData._H5_ALIASES['var']
+                and key != 'raw.var'
+                and not isinstance(value, dict) and value.dtype.names is not None):
+            new_dtype = [((dt[0], 'U{}'.format(int(int(dt[1][2:])/4)))
+                          if dt[1][1] == 'S' else dt) for dt in value.dtype.descr]
+            value = value.astype(new_dtype)
+        return key, value
+
+    #key, value = postprocess_reading(key, value)
+    d[key_write] = value
+    return
+
+
 def read_h5ad(filename, backed: Union[bool, str] = False):
     """Read ``.h5ad``-formatted hdf5 file.
 

--- a/anndata/tests/readwrite.py
+++ b/anndata/tests/readwrite.py
@@ -64,6 +64,19 @@ def test_readwrite_dynamic():
         assert adata.obs['oanno1'].cat.categories.tolist() == ['cat1', 'cat2']
 
 
+def test_readwrite_zarr():
+    for typ in [np.array, csr_matrix]:
+        X = typ(X_list)
+        adata = ad.AnnData(X, obs=obs_dict, var=var_dict, uns=uns_dict)
+        assert pd.api.types.is_string_dtype(adata.obs['oanno1'])
+        adata.write_zarr('./test_zarr_dir', chunks=True)
+        adata = ad.read_zarr('./test_zarr_dir')
+        assert pd.api.types.is_categorical(adata.obs['oanno1'])
+        assert pd.api.types.is_string_dtype(adata.obs['oanno2'])
+        assert adata.obs.index.tolist() == ['name1', 'name2', 'name3']
+        assert adata.obs['oanno1'].cat.categories.tolist() == ['cat1', 'cat2']
+
+
 @pytest.mark.skipif(not find_spec('loompy'), reason='Loompy is not installed (expected on Python 3.5)')
 def test_readwrite_loom():
     for i, typ in enumerate([np.array, csr_matrix]):

--- a/requires.txt
+++ b/requires.txt
@@ -2,3 +2,4 @@ pandas>=0.21.0
 scipy
 h5py
 natsort
+zarr

--- a/requires_tests.txt
+++ b/requires_tests.txt
@@ -1,3 +1,4 @@
 loompy>=2.0; python_version>='3.6'
 pytest-cov
 codecov
+zarr


### PR DESCRIPTION
This change allows Anndata to use [Zarr](http://zarr.readthedocs.io/) as the backing storage. The motivation here is to provide support for Zarr with [Scanpy](http://scanpy.readthedocs.io/) and Spark (although this patch does not have any Spark parts in it). This work can be found in [this repo](https://github.com/lasersonlab/single-cell-experiments).

The code here is based on the HDF5 codepath, although it might be possible to simplify it somewhat, and it also needs docstrings adding. I wanted to submit the PR now to see if there is general interest and if such a change would be considered.

