### PR TITLE
remove loompy.connect.close()

### DIFF
--- a/anndata/readwrite/read.py
+++ b/anndata/readwrite/read.py
@@ -172,7 +172,6 @@ def read_loom(filename: PathLike, sparse: bool = True, cleanup: bool = False, X_
             obs=obs,  # not ideal: make the generator a dict...
             var=var,
             layers=layers)
-        lc.close()
     return adata
 
 


### PR DESCRIPTION
`with loompy.connect("filename") as lc:`
The connection will be automatically closed at the end of the with block.