### PR TITLE
Switch back to 2D-only arrays (WIP)

### DIFF
--- a/anndata/base.py
+++ b/anndata/base.py
@@ -486,7 +486,14 @@ class Raw(IndexMixin):
             X = self._adata.file['raw.X']
             if self._adata.isview: return X[self._adata._oidx, self._adata._vidx]
             else: return X
-        else: return self._X
+        else:
+            if n_obs == 1 and n_vars == 1:
+                return X[0, 0]
+            elif n_obs == 1 or n_vars == 1:
+                if issparse(X): X = X.toarray()
+                return X.flatten()
+            else:
+                return self._X
 
     @property
     def var(self):

--- a/anndata/readwrite/read.py
+++ b/anndata/readwrite/read.py
@@ -474,7 +474,8 @@ def _read_key_value_from_h5(f, d, key, key_write=None):
     # the '()' means 'load everything into memory' (by contrast, ':'
     # only works if not reading a scalar type)
     def postprocess_reading(key, value):
-        if value.ndim == 1 and len(value) == 1:
+        # record arrays should stay record arrays and not become scalars
+        if value.ndim == 1 and len(value) == 1 and not value.dtype != np.record:
             value = value[0]
         if value.dtype.kind == 'S':
             value = value.astype(str)

--- a/anndata/readwrite/write.py
+++ b/anndata/readwrite/write.py
@@ -67,9 +67,9 @@ def write_csvs(dirname: PathLike, adata: AnnData, skip_data: bool = True, sep: s
 
 def write_loom(filename: PathLike, adata: AnnData):
     filename = Path(filename)
-    row_attrs = adata.var.to_dict('list')
+    row_attrs = {k: np.array(v) for k, v in adata.var.to_dict('list').items()}
     row_attrs['var_names'] = adata.var_names.values
-    col_attrs = adata.obs.to_dict('list')
+    col_attrs = {k: np.array(v) for k, v in adata.obs.to_dict('list').items()}
     col_attrs['obs_names'] = adata.obs_names.values
     
     layers = {'': adata.X.T}

--- a/anndata/tests/base.py
+++ b/anndata/tests/base.py
@@ -22,8 +22,6 @@ def test_creation():
     assert adata.raw.X.tolist() == X.tolist()
     assert adata.raw.var_names.tolist() == ['a', 'b', 'c']
 
-    assert AnnData(np.array([1, 2])).X.shape == (1, 2)
-
     from pytest import raises
     with raises(ValueError):
         AnnData(
@@ -70,23 +68,16 @@ def test_indices_dtypes():
     assert adata.obs_names.tolist() == ['ö', 'a']
 
 
-def test_creation_from_vector():
-    adata = AnnData(np.array([1, 2, 3]))
-    assert adata.X.shape == (1, 3)
-    adata = AnnData(np.array([[1], [2], [3]]))
-    assert adata.X.shape == (3, 1)
-
 
 def test_slicing():
     adata = AnnData(np.array([[1, 2, 3],
                               [4, 5, 6]]))
 
-    # anndata maintains 2D shape, numpy doesn’t
-    assert adata[:, 0].X.tolist() == adata.X[:, 0].reshape((2, 1)).tolist()
+    assert adata[:, 0].X.tolist() == adata.X[:, 0].tolist()
 
-    assert adata[0, 0].X.tolist() == [[1]]
-    assert adata[0, :].X.tolist() == [[1, 2, 3]]
-    assert adata[:, 0].X.tolist() == [[1], [4]]
+    assert adata[0, 0].X.tolist() == 1
+    assert adata[0, :].X.tolist() == [1, 2, 3]
+    assert adata[:, 0].X.tolist() == [1, 4]
 
     assert adata[:, [0, 1]].X.tolist() == [[1, 2], [4, 5]]
     assert adata[:, np.array([0, 2])].X.tolist() == [[1, 3], [4, 6]]
@@ -100,9 +91,9 @@ def test_slicing_strings():
         dict(obs_names=['A', 'B']),
         dict(var_names=['a', 'b', 'c']))
 
-    assert adata['A', 'a'].X.tolist() == [[1]]
-    assert adata['A', :].X.tolist() == [[1, 2, 3]]
-    assert adata[:, 'a'].X.tolist() == [[1], [4]]
+    assert adata['A', 'a'].X.tolist() == 1
+    assert adata['A', :].X.tolist() == [1, 2, 3]
+    assert adata[:, 'a'].X.tolist() == [1, 4]
     assert adata[:, ['a', 'b']].X.tolist() == [[1, 2], [4, 5]]
     assert adata[:, np.array(['a', 'c'])].X.tolist() == [[1, 3], [4, 6]]
     assert adata[:, 'b':'c'].X.tolist() == [[2, 3], [5, 6]]
@@ -143,7 +134,7 @@ def test_slicing_remove_unused_categories():
         np.array([[1, 2], [3, 4], [5, 6], [7, 8]]),
         dict(k=['a', 'a', 'b', 'b']))
     adata._sanitize()
-    assert adata[3:5].obs['k'].cat.categories.tolist() == ['b']
+    assert adata[2:4].obs['k'].cat.categories.tolist() == ['b']
 
 
 def test_slicing_integer_index():
@@ -330,6 +321,7 @@ def test_rename_categories():
     assert list(adata.uns['tool']['cat_array'].dtype.names) == new_categories
 
 def test_pickle():
+    import pickle
     adata = AnnData()
     adata2 = pickle.loads(pickle.dumps(adata))
     assert adata2.obsm._parent == adata2

--- a/anndata/tests/readwrite.py
+++ b/anndata/tests/readwrite.py
@@ -55,6 +55,15 @@ def test_readwrite_h5ad(typ):
 
 
 @pytest.mark.parametrize('typ', [np.array, csr_matrix])
+def test_readwrite_h5ad_one_dimensino(typ):
+    X = typ(X_list)
+    adata = ad.AnnData(X, obs=obs_dict, var=var_dict, uns=uns_dict)
+    adata = adata[:, 0].copy()
+    adata.write('./test.h5ad')
+    adata = ad.read('./test.h5ad')
+
+
+@pytest.mark.parametrize('typ', [np.array, csr_matrix])
 def test_readwrite_dynamic(typ):
     X = typ(X_list)
     adata = ad.AnnData(X, obs=obs_dict, var=var_dict, uns=uns_dict)

--- a/anndata/utils.py
+++ b/anndata/utils.py
@@ -1,7 +1,7 @@
 import logging as logg
 import warnings
 from functools import wraps
-from typing import Mapping, Any, Sequence
+from typing import Mapping, Any, Sequence, Union, Sized, Optional
 
 import pandas as pd
 import numpy as np
@@ -119,3 +119,20 @@ class DeprecationMixinMeta(type):
             item for item in type.__dir__(cls)
             if not is_deprecated(getattr(cls, item, None))
         ]
+
+
+Index = Union[slice, int, np.int64, np.ndarray, Sized]
+
+
+def get_n_items_idx(idx: Index, l: int):
+    if isinstance(idx, np.ndarray) and idx.dtype == bool:
+        return idx.sum()
+    elif isinstance(idx, slice):
+        start = 0 if idx.start is None else idx.start
+        stop = l if idx.stop is None else idx.stop
+        step = 1 if idx.step is None else idx.step
+        return (stop - start) // step
+    elif isinstance(idx, (int, np.int_)):
+        return 1
+    else:
+        return len(idx)


### PR DESCRIPTION
We have always either no data or 2D data. Representing this super flexibly as scalar or 1D array is error-prone, and making it one explicitly is one `.flatten()` away for the user.

Fixes #42, fixes #56