### PR TITLE
Method to_df() to transform anndata in pandas DF

### DIFF
--- a/anndata/base.py
+++ b/anndata/base.py
@@ -1522,6 +1522,14 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
                        filename=self.filename, layers=layers)
 
     T = property(transpose)
+    
+    def to_df(self):
+        """Generate shallow pandas DataFrame.
+
+        Data matrix is returned as pandas DataFrame, where observation names are on index,
+        and variable names on columns.
+        """
+        return pd.DataFrame(self.X, index=self.obs_names, columns=self.var_names)
 
     def copy(self, filename=None):
         """Full copy, optionally on disk."""


### PR DESCRIPTION
It should implement the transformation only to a shallow dataframe (X, with obs_names and var_names as indexes).
It only bugs me that the dataframe returned has a slightly different precision than the one used to initialize the AnnData, eg:

```python
> import pandas as pd
> import anndata as an
> df = pd.DataFrame(pd.np.random.rand(10,10), index=range(10), columns=range(10,20))
> df2 = an.AnnData(df, obs=df.index, var=df.columns).to_df()
> (df - df2).abs().max().max()
2.943521026921303e-08
```