### PR TITLE
Fix numpy compatibility operator in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas>=0.21.0
-numpy~=1.14.0
+numpy~=1.14
 scipy~=1.0
 h5py
 natsort


### PR DESCRIPTION
Current requirement is incompatible with numpy 1.15, which is not we want. See https://github.com/theislab/anndata/commit/8d331cfcebb06ed202c7db3a1690b8bf7e6453d1#r30515166 for the discussion.

What do you think @flying-sheep ?