### PR TITLE
use read_direct in read_h5ad

### DIFF
--- a/anndata/h5py/utils.py
+++ b/anndata/h5py/utils.py
@@ -1,9 +1,23 @@
-def _chunked_rows(X, chunk_size=1000):
+import numpy as np
+
+def _chunked_rows(X, chunk_size=1000, read=False):
     start = 0
+    type = X.dtype
     n = X.shape[0]
+    m = X.shape[1]
+    data_array = np.empty((chunk_size, m), type) if read else None
     for _ in range(int(n // chunk_size)):
         end = start + chunk_size
-        yield (X[start:end], start, end)
+        if read:
+            X.read_direct(data_array, source_sel=np.s_[start:end,:])
+        else:
+            data_array = X[start:end]
+        yield (data_array, start, end)
         start = end
     if start < n:
-        yield (X[start:n], start, n)
+        if read:
+            data_array = np.empty((n-start+1, m), type)
+            X.read_direct(data_array, source_sel=np.s_[start:n,:])
+        else:
+            data_array = X[start:n]
+        yield (data_array, start, n)

--- a/anndata/readwrite/read.py
+++ b/anndata/readwrite/read.py
@@ -139,13 +139,13 @@ def read_loom(filename: PathLike, sparse: bool = True, cleanup: bool = False, X_
         The filename.
     sparse
         Whether to read the data matrix as sparse.
-    cleanup: 
+    cleanup:
         Whether to remove all obs/var keys that do not store more than one unique value.
     X_name:
         Loompy key where the data matrix is stored.
     obs_names:
         Loompy key where the observation/cell names are stored.
-    var_names: 
+    var_names:
         Loompy key where the variable/gene names are stored.
     """
     filename = fspath(filename)  # allow passing pathlib.Path objects
@@ -487,6 +487,11 @@ def _read_key_value_from_h5(f, d, key, key_write=None):
 
     if isinstance(ds, h5py.Dataset) and 'sparse_format' in ds.attrs:
         value = h5py._load_h5_dataset_as_sparse(ds)
+    elif isinstance(ds, h5py.Dataset):
+        value = np.empty(ds.shape, ds.dtype)
+        ds.read_direct(value)
+    elif isinstance(ds, h5py.SparseDataset):
+        value = ds.value
     else:
         value = ds[()]
     # the '()' means 'load everything into memory' (by contrast, ':'


### PR DESCRIPTION
https://github.com/Koncopd/anndata-scanpy-benchmarks/blob/master/memory_issue_huge.ipynb
here added the same changes as in the test code for `read_h5ad('1M_neurons.h5ad', rd=True)` from the benchmark above.
solves https://github.com/theislab/scanpy/issues/146