### PR TITLE
Windows bugfix when generating views of a single index.

### DIFF
--- a/anndata/utils.py
+++ b/anndata/utils.py
@@ -143,7 +143,7 @@ def get_n_items_idx(idx: Index, l: int):
         stop = l if idx.stop is None else idx.stop
         step = 1 if idx.step is None else idx.step
         return (stop - start) // step
-    elif isinstance(idx, (int, np.int_)):
+    elif isinstance(idx, (int, np.int_, np.int64, np.int32)):
         return 1
     else:
         return len(idx)


### PR DESCRIPTION
Hi!
Running this code:
```
import numpy as np
X = np.array([[1, 2], [2,3]])
var = {'var_names': ['a', 'b']}
import anndata as ad
adata = ad.AnnData(X, var=var)
np.array(adata[:, 'a'].X)
```
Gives an error on Windows computers.
Whereas instead of the last line
`np.array(adata[:, ['a']].X)`
works fine.
This is probably due to the [weird way Windows defines np.int_](https://github.com/numpy/numpy/issues/9464):
`np.int64 in (np.int_, int)` gives False, but True for np.int32, even though I have Windows 64bit Version. So I changed an if-check to include the windows case.