### PR TITLE
Write variable length strings

### DIFF
--- a/anndata/base.py
+++ b/anndata/base.py
@@ -193,9 +193,10 @@ def _gen_keys_from_multicol_key(key_multicol, n_keys):
 def df_to_records_fixed_width(df):
     uns = {}  # unstructured dictionary for storing categories
     names = ['index']
+    obj_type = h5py.special_dtype(vlen=str)
     if is_string_dtype(df.index):
         max_len_index = 0 if 0 in df.shape else df.index.map(len).max()
-        index = df.index.values.astype('S{}'.format(max_len_index))
+        index = df.index.values.astype(obj_type)
     else:
         index = df.index.values
     arrays = [index]
@@ -204,7 +205,7 @@ def df_to_records_fixed_width(df):
         if is_string_dtype(df[k]) and not is_categorical(df[k]):
             lengths = df[k].map(len)
             if is_categorical(lengths): lengths = lengths.cat.as_ordered()
-            arrays.append(df[k].values.astype('S{}'.format(lengths.max())))
+            arrays.append(df[k].values.astype(obj_type))
         elif is_categorical(df[k]):
             uns[k + '_categories'] = df[k].cat.categories
             arrays.append(df[k].cat.codes)
@@ -462,7 +463,7 @@ class Raw(IndexMixin):
                 return X.flatten()
             else:
                 return self._X
-            
+
     @property
     def shape(self):
         return self.X.shape
@@ -1855,7 +1856,7 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
             else:
                 Xs.append(ad[:, vars_intersect].X)
             obs_i += ad.n_obs
-            
+
             # layers
             if join == 'inner':
                 for key in shared_layers:
@@ -1884,7 +1885,7 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
                 X = vstack(Xs)
             else:
                 X = np.concatenate(Xs)
-                
+
             for key in shared_layers:
                 if any(issparse(a.layers[key]) for a in all_adatas):
                     layers[key] = vstack(layers[key])
@@ -1955,7 +1956,7 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
         """Write ``.h5ad``-formatted hdf5 file.
 
         .. note::
-           
+
             Setting compression to ``'gzip'`` can save disk space but
             will slow down writing and subsequent reading. Prior to
             v0.6.16, this was the default for parameter
@@ -1964,9 +1965,9 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
         Generally, if you have sparse data that are stored as a dense
         matrix, you can dramatically improve performance and reduce
         disk space by converting to a :class:`~scipy.sparse.csr_matrix`::
-        
+
             from scipy.sparse import csr_matrix
-            adata.X = csr_matrix(adata.X) 
+            adata.X = csr_matrix(adata.X)
 
         Parameters
         ----------

--- a/anndata/readwrite/write.py
+++ b/anndata/readwrite/write.py
@@ -251,7 +251,7 @@ def _write_key_value_to_h5(f, key, value, **kwargs):
             value = np.array(value)  # make sure value is an array
             if value.ndim == 0: value = np.array([value])  # hm, why that?
         # make sure string format is chosen correctly
-        if value.dtype.kind == 'U': value = value.astype(np.string_)
+        if value.dtype.kind == 'U': value = value.astype(h5py.special_dtype(vlen=str))
         return value
 
     value = preprocess_writing(value)

--- a/anndata/readwrite/write.py
+++ b/anndata/readwrite/write.py
@@ -89,7 +89,7 @@ def write_loom(filename: PathLike, adata: AnnData):
 def write_zarr(store: Union[MutableMapping, PathLike], adata: AnnData, **kwargs):
     if isinstance(store, Path):
         store = str(store)
-    d = adata._to_dict_fixed_width_arrays()
+    d = adata._to_dict_fixed_width_arrays(var_len_str=False)
     import zarr
     f = zarr.open(store, mode='w')
     for key, value in d.items():


### PR DESCRIPTION
Use only variable length strings in h5ad. Prevents problems when converting very long variable length strings to fixed length strings.
Variable length strings in h5ad seem to solve memory and runtime problems discussed with @falexwolf .
![image](https://user-images.githubusercontent.com/3065736/51809098-3e2f2e00-229d-11e9-9ff3-7f525fb5e35d.png)
