### PR TITLE
Don't convert to categorical if it's already categorical

### DIFF
--- a/anndata/base.py
+++ b/anndata/base.py
@@ -1394,7 +1394,8 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
         else:
             dfs = [df]
         for df in dfs:
-            string_cols = [key for key in df.columns if is_string_dtype(df[key])]
+            string_cols = [key for key in df.columns if is_string_dtype(df[key]) \
+                           and not is_categorical(df[key])]
             for key in string_cols:
                 # make sure we only have strings (could be that there are
                 # np.nans (float), -666, '-666', for instance)


### PR DESCRIPTION
Quick fix for https://github.com/theislab/scanpy/issues/448

Fun fact (for at least pandas `v0.24.0` & `v0.22.0`):

```python
>>> import pandas as pd
>>> from pandas.api.types import is_string_dtype
>>> is_string_dtype(pd.Categorical([1,2,3]))
True
```