### PR TITLE
Write obsm/varm to loom file on request

### DIFF
--- a/anndata/base.py
+++ b/anndata/base.py
@@ -2021,7 +2021,7 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
         from .readwrite.write import write_csvs
         write_csvs(dirname, self, skip_data=skip_data, sep=sep)
 
-    def write_loom(self, filename: PathLike, write_embeddings: bool = False):
+    def write_loom(self, filename: PathLike, write_obsm_varm: bool = False):
         """Write ``.loom``-formatted hdf5 file.
 
         Parameters
@@ -2030,7 +2030,7 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
             The filename.
         """
         from .readwrite.write import write_loom
-        write_loom(filename, self, write_embeddings = write_embeddings)
+        write_loom(filename, self, write_obsm_varm = write_obsm_varm)
 
     def write_zarr(
         self,

--- a/anndata/base.py
+++ b/anndata/base.py
@@ -2021,7 +2021,7 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
         from .readwrite.write import write_csvs
         write_csvs(dirname, self, skip_data=skip_data, sep=sep)
 
-    def write_loom(self, filename: PathLike):
+    def write_loom(self, filename: PathLike, write_embeddings: bool = False):
         """Write ``.loom``-formatted hdf5 file.
 
         Parameters
@@ -2030,7 +2030,7 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
             The filename.
         """
         from .readwrite.write import write_loom
-        write_loom(filename, self)
+        write_loom(filename, self, write_embeddings = write_embeddings)
 
     def write_zarr(
         self,

--- a/anndata/readwrite/read.py
+++ b/anndata/readwrite/read.py
@@ -164,11 +164,21 @@ def read_loom(filename: PathLike, sparse: bool = True, cleanup: bool = False, X_
         for key in lc.layers.keys():
             if key != '': layers[key] = lc.layers[key].sparse().T.tocsr() if sparse else lc.layers[key][()].T
 
-        obs=dict(lc.col_attrs)
+        obs = dict(lc.col_attrs)
         if obs_names in obs.keys(): obs['obs_names'] = obs.pop(obs_names)
+        obsm_attrs = [k for k, v in obs.items() if v.ndim > 1 and v.shape[1] > 1]
 
-        var=dict(lc.row_attrs)
+        obsm = {}
+        for key in obsm_attrs:
+            obsm[key] = obs.pop(key)
+
+        var = dict(lc.row_attrs)
         if var_names in var.keys(): var['var_names'] = var.pop(var_names)
+        varm_attrs = [k for k, v in var.items() if v.ndim > 1 and v.shape[1] > 1]
+
+        varm = {}
+        for key in varm_attrs:
+            varm[key] = var.pop(key)
 
         if cleanup:
             for key in list(obs.keys()):
@@ -183,6 +193,8 @@ def read_loom(filename: PathLike, sparse: bool = True, cleanup: bool = False, X_
             obs=obs,  # not ideal: make the generator a dict...
             var=var,
             layers=layers,
+            obsm=obsm if obsm else None,
+            varm=varm if varm else None,
             dtype=dtype)
     return adata
 

--- a/anndata/readwrite/write.py
+++ b/anndata/readwrite/write.py
@@ -67,7 +67,7 @@ def write_csvs(dirname: PathLike, adata: AnnData, skip_data: bool = True, sep: s
         )
 
 
-def write_loom(filename: PathLike, adata: AnnData, write_embeddings: bool = False):
+def write_loom(filename: PathLike, adata: AnnData, write_obsm_varm: bool = False):
     filename = Path(filename)
     row_attrs = {k: np.array(v) for k, v in adata.var.to_dict('list').items()}
     row_attrs['var_names'] = adata.var_names.values
@@ -77,13 +77,11 @@ def write_loom(filename: PathLike, adata: AnnData, write_embeddings: bool = Fals
     if adata.X is None:
         raise ValueError('loompy does not accept empty matrices as data')
 
-    if write_embeddings:
+    if write_obsm_varm:
         for key in adata.obsm.keys():
-            for i in range(adata.obsm[key].shape[1]):
-                col_attrs['obsm_{}_{}'.format(key, i+1)] = adata.obsm[key][:, i]
+            col_attrs[key] = adata.obsm[key]
         for key in adata.varm.keys():
-            for i in range(adata.varm[key].shape[1]):
-                row_attrs['varm_{}_{}'.format(key, i+1)] = adata.varm[key][:, i]
+            row_attrs[key] = adata.varm[key]
     else:
         if len(adata.obsm.keys()) > 0 or len(adata.varm.keys()) > 0:
             logger.warning(

--- a/anndata/readwrite/write.py
+++ b/anndata/readwrite/write.py
@@ -80,10 +80,10 @@ def write_loom(filename: PathLike, adata: AnnData, write_embeddings: bool = Fals
     if write_embeddings:
         for key in adata.obsm.keys():
             for i in range(adata.obsm[key].shape[1]):
-                col_attrs[f'obsm_{key}_{i+1}'] = adata.obsm[key][:, i]
+                col_attrs['obsm_{}_{}'.format(key, i+1)] = adata.obsm[key][:, i]
         for key in adata.varm.keys():
             for i in range(adata.varm[key].shape[1]):
-                row_attrs[f'varm_{key}_{i+1}'] = adata.varm[key][:, i]
+                row_attrs['varm_{}_{}'.format(key, i+1)] = adata.varm[key][:, i]
     else:
         if len(adata.obsm.keys()) > 0 or len(adata.varm.keys()) > 0:
             logger.warning(

--- a/anndata/readwrite/write.py
+++ b/anndata/readwrite/write.py
@@ -86,7 +86,7 @@ def write_loom(filename: PathLike, adata: AnnData, write_obsm_varm: bool = False
         if len(adata.obsm.keys()) > 0 or len(adata.varm.keys()) > 0:
             logger.warning(
                 'The loom file will lack these fields:\n{}\n'
-                'Use write_embeddings=True to export embeddings.'
+                'Use write_obsm_varm=True to export multi-dimensional annotations'
                 .format(adata.obsm.keys() + adata.varm.keys()))
 
     layers = {'': adata.X.T}

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -123,8 +123,8 @@ def test_readwrite_loom(typ, tmp_path):
     X = typ(X_list)
     adata_src = ad.AnnData(X, obs=obs_dict, var=var_dict, uns=uns_dict)
     adata_src.obsm['X_a'] = np.zeros((adata_src.n_obs, 2))
-    adata_src.varm['X_b'] = np.zeros((adata_src.n_vars, 2))
-    adata_src.write_loom(tmp_path / 'test.loom', write_embeddings=True)
+    adata_src.varm['X_b'] = np.zeros((adata_src.n_vars, 3))
+    adata_src.write_loom(tmp_path / 'test.loom', write_obsm_varm=True)
 
     adata = ad.read_loom(tmp_path / 'test.loom', sparse=typ is csr_matrix)
     if isinstance(X, np.ndarray):
@@ -132,6 +132,8 @@ def test_readwrite_loom(typ, tmp_path):
     else:
         # TODO: this should not be necessary
         assert np.allclose(adata.X.toarray(), X.toarray())
+    assert 'X_a' in adata.obsm_keys() and adata.obsm['X_a'].shape[1] == 2
+    assert 'X_b' in adata.varm_keys() and adata.varm['X_b'].shape[1] == 3
 
 
 def test_read_csv():

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -122,7 +122,9 @@ def test_readwrite_zarr(typ, tmp_path):
 def test_readwrite_loom(typ, tmp_path):
     X = typ(X_list)
     adata_src = ad.AnnData(X, obs=obs_dict, var=var_dict, uns=uns_dict)
-    adata_src.write_loom(tmp_path / 'test.loom')
+    adata_src.obsm['X_a'] = np.zeros((adata_src.n_obs, 2))
+    adata_src.varm['X_b'] = np.zeros((adata_src.n_vars, 2))
+    adata_src.write_loom(tmp_path / 'test.loom', write_embeddings=True)
 
     adata = ad.read_loom(tmp_path / 'test.loom', sparse=typ is csr_matrix)
     if isinstance(X, np.ndarray):


### PR DESCRIPTION
It'd be nice to have a way to export embeddings into loom files. Since this is ugly and likely to create many keys in col and row attributes, we can keep it disabled by default. But the users should be able to do it if they want, I think.