### PR TITLE
Maintain dtype during initialization

### DIFF
--- a/anndata/base.py
+++ b/anndata/base.py
@@ -653,7 +653,7 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
         varm: Optional[Union[np.ndarray, Mapping[str, Sequence[Any]]]] = None,
         layers: Optional[Mapping[str, Union[np.ndarray, sparse.spmatrix]]] = None,
         raw: Optional[Raw] = None,
-        dtype: Union[np.dtype, str] = 'float32',
+        dtype: Union[np.dtype, str] = None,
         shape: Optional[Tuple[int, int]] = None,
         filename: Optional[PathLike] = None,
         filemode: Optional[str] = None,
@@ -759,7 +759,7 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
     def _init_as_actual(
             self, X=None, obs=None, var=None, uns=None,
             obsm=None, varm=None, raw=None, layers=None,
-            dtype='float32', shape=None,
+            dtype=None, shape=None,
             filename=None, filemode=None):
         from .readwrite.read import _read_args_from_h5ad
 
@@ -817,14 +817,11 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
                 raise ValueError('`shape` needs to be `None` is `X` is not `None`.')
             _check_2d_shape(X)
             # if type doesn't match, a copy is made, otherwise, use a view
-            if issparse(X) or isinstance(X, ma.MaskedArray):
-                # TODO: maybe use view on data attribute of sparse matrix
-                #       as in readwrite.read_10x_h5
-                if X.dtype != np.dtype(dtype): X = X.astype(dtype)
-            elif isinstance(X, ZarrArray):
-                X = X.astype(dtype)
-            else:  # is np.ndarray
-                X = X.astype(dtype, copy=False)
+            if dtype is not None:
+                if issparse(X) or isinstance(X, ma.MaskedArray) or isinstance(X, ZarrArray):
+                    X = X.astype(dtype)
+                else:  # is np.ndarray
+                    X = X.astype(dtype, copy=False)
             # data matrix and shape
             self._X = X
             self._n_obs, self._n_vars = self._X.shape
@@ -1818,7 +1815,12 @@ class AnnData(IndexMixin, metaclass=utils.DeprecationMixinMeta):
             if any_sparse:  # not sure whether the lil_matrix is really the best option
                 X = sparse.lil_matrix(out_shape, dtype=self.X.dtype)
             else:
-                X = np.empty(out_shape, dtype=self.X.dtype)
+                if np.issubdtype(self.X.dtype, np.integer):
+                    dtype = 'float32'
+                    logger.warning('Transforming to `float32` as integer cannot represent NaNs.')
+                else:
+                    dtype = self.X.dtype
+                X = np.empty(out_shape, dtype=dtype)
                 X[:] = np.nan
         else:
             Xs = []

--- a/anndata/layers.py
+++ b/anndata/layers.py
@@ -13,7 +13,7 @@ class AnnDataLayers:
         self,
         adata: 'AnnData',
         layers: Optional[Mapping[str, np.ndarray]] = None,
-        dtype: Union[str, np.dtype] = 'float32',
+        dtype: Union[str, np.dtype] = None,
         adata_ref: 'AnnData' = None,
         oidx: 'Index' = None,
         vidx: 'Index' = None,
@@ -32,11 +32,10 @@ class AnnDataLayers:
                     .format(key, type(layer).__name__)
                 )
             if layer.shape != self._adata.shape:
-                raise ValueError('Shape does not fit.')
-            if layer.dtype != np.dtype(dtype):
+                raise ValueError('Shape of layer {} does not fit.'.format(key))
+            if dtype is not None:
                 self._layers[key] = layer.astype(dtype, copy=False)
-            else:
-                self._layers[key] = layer
+            self._layers[key] = layer
 
     def __getitem__(self, key):
         if self.isview:

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -331,6 +331,11 @@ def test_concatenate():
         [np.nan, 6.0, 5.0, 4.0],
         [np.nan, 3.0, 2.0, 1.0],
         [np.nan, 6.0, 5.0, 4.0]]))
+    print(Xma.dtype)
+    print(Xma)
+    print(Xma.mask)
+    print(Xma_ref)
+    print(Xma_ref.mask)
     assert np.array_equal(Xma.mask, Xma_ref.mask)
     assert np.allclose(Xma.compressed(), Xma_ref.compressed())
     var_ma = ma.masked_invalid(adata.var.values.tolist())

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,6 +9,7 @@ On master :small:`March 23, 2019`
 ---------------------------------
 
 - maintain dtype upon read/write :noteversion:`to appear as 0.7`
+- maintain dtype during initialization :noteversion:`to appear as 0.7`
 - bug fix for https://github.com/theislab/anndata/issues/126 :noteversion:`0.6.19`
 - bug fix for reading excel files :noteversion:`0.6.19`
 - :attr:`~anndata.AnnData.layers` inspired by `.loom <http://loompy.org>`__ files allows their information lossless reading via :func:`~anndata.read_loom`


### PR DESCRIPTION
Sorry about the confusion here. The commit had wider implications on the Scanpy tests than expected.

Needs to be merged within https://github.com/theislab/scanpy/issues/453.