### PR TITLE
adds support for composing obsm from 1D loom attributes

### DIFF
--- a/anndata/readwrite/read.py
+++ b/anndata/readwrite/read.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Union, Optional
+from typing import Union, Optional, Mapping
 from typing import Iterable, Iterator, Generator
 from collections import OrderedDict
 import gzip
@@ -126,9 +126,16 @@ def read_hdf(filename: PathLike, key: str) -> AnnData:
     return adata
 
 
-def read_loom(filename: PathLike, sparse: bool = True, cleanup: bool = False, X_name: str = 'spliced',
-              obs_names: str = 'CellID', var_names: str = 'Gene', dtype: str='float32', **kwargs) -> AnnData:
-    """Read `.loom`-formatted hdf5 file.
+def read_loom(filename: PathLike,
+              sparse: bool = True,
+              cleanup: bool = False,
+              X_name: str = 'spliced',
+              obs_names: str = 'CellID',
+              obsm_names: Optional[Mapping[str, Iterable[str]]] = None,
+              var_names: str = 'Gene',
+              varm_names: Optional[Mapping[str, Iterable[str]]] = None,
+              dtype: str='float32', **kwargs) -> AnnData:
+    """Read ``.loom``-formatted hdf5 file.
 
     This reads the whole file into memory.
 
@@ -147,11 +154,18 @@ def read_loom(filename: PathLike, sparse: bool = True, cleanup: bool = False, X_
         Loompy key with which the data matrix `.X` is initialized.
     obs_names
         Loompy key where the observation/cell names are stored.
-    var_names
+    obsm_names:
+        Loompy keys which will be constructed into observation matrices
+    var_names:
         Loompy key where the variable/gene names are stored.
-    **kwargs
+    obsm_names:
+        Loompy keys which will be constructed into variable matrices
+    **kwargs:
         Arguments to loompy.connect
     """
+    obsm_names = obsm_names or {}
+    varm_names = varm_names or {}
+
     filename = fspath(filename)  # allow passing pathlib.Path objects
     from loompy import connect
     with connect(filename, 'r', **kwargs) as lc:
@@ -165,18 +179,26 @@ def read_loom(filename: PathLike, sparse: bool = True, cleanup: bool = False, X_
             if key != '': layers[key] = lc.layers[key].sparse().T.tocsr() if sparse else lc.layers[key][()].T
 
         obs = dict(lc.col_attrs)
+
+        obsm = {}
+        for key, names in obsm_names.items():
+            obsm[key] = np.array([obs.pop(name) for name in names]).T
+
         if obs_names in obs.keys(): obs['obs_names'] = obs.pop(obs_names)
         obsm_attrs = [k for k, v in obs.items() if v.ndim > 1 and v.shape[1] > 1]
 
-        obsm = {}
         for key in obsm_attrs:
             obsm[key] = obs.pop(key)
 
         var = dict(lc.row_attrs)
+
+        varm = {}
+        for key, names in varm_names.items():
+            varm[key] = np.array([var.pop(name) for name in names]).T
+
         if var_names in var.keys(): var['var_names'] = var.pop(var_names)
         varm_attrs = [k for k, v in var.items() if v.ndim > 1 and v.shape[1] > 1]
 
-        varm = {}
         for key in varm_attrs:
             varm[key] = var.pop(key)
 

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -37,11 +37,14 @@ obs_dict = dict(  # annotation of observations / rows
     oanno1b=['cat1', 'cat1', 'cat1'],       # categorical annotation with one category
     oanno2=['o1', 'o2', 'o3'],              # string annotation
     oanno3=[2.1, 2.2, 2.3],                 # float annotation
+    oanno4=[3.3, 1.1, 2.2],                 # float annotation
 )
 
 var_dict = dict(  # annotation of variables / columns
     vanno1=[3.1, 3.2],
     vanno2=['cat1', 'cat1'],  # categorical annotation
+    vanno3=[2.1, 2.2],                 # float annotation
+    vanno4=[3.3, 1.1],                 # float annotation
 )
 
 uns_dict = dict(  # unstructured annotation
@@ -159,14 +162,22 @@ def test_readwrite_zarr(typ, tmp_path):
 
 @pytest.mark.skipif(not find_spec('loompy'), reason='Loompy is not installed (expected on Python 3.5)')
 @pytest.mark.parametrize('typ', [np.array, csr_matrix])
-def test_readwrite_loom(typ, tmp_path):
+@pytest.mark.parametrize('obsm_names',[{},{'X_composed':['oanno3', 'oanno4']}])
+@pytest.mark.parametrize('varm_names',[{},{'X_composed2':['vanno3', 'vanno4']}])
+def test_readwrite_loom(typ, obsm_names, varm_names, tmp_path):
     X = typ(X_list)
     adata_src = ad.AnnData(X, obs=obs_dict, var=var_dict, uns=uns_dict)
     adata_src.obsm['X_a'] = np.zeros((adata_src.n_obs, 2))
     adata_src.varm['X_b'] = np.zeros((adata_src.n_vars, 3))
     adata_src.write_loom(tmp_path / 'test.loom', write_obsm_varm=True)
 
-    adata = ad.read_loom(tmp_path / 'test.loom', sparse=typ is csr_matrix, cleanup=True)
+    adata = ad.read_loom(
+        tmp_path / 'test.loom',
+        sparse=typ is csr_matrix,
+        obsm_names=obsm_names,
+        varm_names=varm_names,
+        cleanup=True,
+        )
     if isinstance(X, np.ndarray):
         assert np.allclose(adata.X, X)
     else:
@@ -177,6 +188,11 @@ def test_readwrite_loom(typ, tmp_path):
     # as we called with `cleanup=True`
     assert 'oanno1b' in adata.uns['loom-obs']
     assert 'vanno2' in adata.uns['loom-var']
+    for k,v in  obsm_names.items():
+        assert k in adata.obsm_keys() and adata.obsm[k].shape[1] == len(v)
+    for k,v in  varm_names.items():
+        assert k in adata.varm_keys() and adata.varm[k].shape[1] == len(v)
+
 
 
 def test_read_csv():


### PR DESCRIPTION
implements #131 

tests pass.

I only implemented this for `.obsm` but once I dove in, I realized this same pattern might be relevant for `.varm`?