### PR TITLE
Add obs_array and var_array functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: xenial
 language: python
 cache: pip
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
 install:

--- a/anndata/base.py
+++ b/anndata/base.py
@@ -9,6 +9,7 @@ from typing import Any, Union, Optional
 from typing import Iterable, Sized, Sequence, Mapping, MutableMapping
 from typing import Tuple, List, Dict, KeysView
 from copy import deepcopy
+import warnings
 
 import numpy as np
 from numpy import ma
@@ -1611,7 +1612,11 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             if "X" in self.layers:
                 pass
             else:
-                # TODO: Raise deprecation warning
+                warnings.warn(
+                    "In a future version of AnnData, access to `.X` by passing"
+                    " `layer='X'` will be removed. Instead pass `layer=None`.",
+                    FutureWarning
+                )
                 layer = None
 
         if k in self.obs:
@@ -1650,7 +1655,11 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             if "X" in self.layers:
                 pass
             else:
-                # TODO: Raise deprecation warning
+                warnings.warn(
+                    "In a future version of AnnData, access to `.X` by passing"
+                    " `layer='X'` will be removed. Instead pass `layer=None`.",
+                    FutureWarning
+                )
                 layer = None
 
         if k in self.var:

--- a/anndata/base.py
+++ b/anndata/base.py
@@ -1663,7 +1663,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 layer = None
 
         if k in self.var:
-            a = self.var[k].values
+            return self.var[k].values
         else:
             idx = self._normalize_indices((k, slice(None)))
             a = self._get_X(layer=layer)[idx]
@@ -1675,13 +1675,19 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
     def _get_obs_array(self, k, use_raw=False, layer=None):
         """Get an array from the layer (default layer='X') along the observation dimension by first looking up
         obs.keys and then var.index."""
-        return self.obs_vector(k=k, use_raw=use_raw, layer=layer)
+        if use_raw:
+            return self.raw.obs_vector(k)
+        else:
+            return self.obs_vector(k=k, layer=layer)
 
     @utils.deprecated("var_vector")
-    def _get_var_array(self, k, use_raw=False, layer='X'):
+    def _get_var_array(self, k, use_raw=False, layer=None):
         """Get an array from the layer (default layer='X') along the variables dimension by first looking up
         ``var.keys`` and then ``obs.index``."""
-        return self.var_vector(k=k, use_raw=use_raw, layer=layer)
+        if use_raw:
+            return self.raw.var_vector(k)
+        else:
+            return self.var_vector(k=k, layer=layer)
 
     def copy(self, filename: Optional[PathLike] = None) -> 'AnnData':
         """Full copy, optionally on disk."""

--- a/anndata/base.py
+++ b/anndata/base.py
@@ -462,6 +462,56 @@ class Raw:
             self._var = adata.var.copy()
             self._varm = adata.varm.copy()
 
+    def var_array(self, k: str) -> np.ndarray:
+        """
+        Convenience function for returning a 1 dimensional ndarray of values
+        from `.X` or `.var`.
+
+        Made for convenience, not performance. Intentionally permissive about
+        arguments, for easy iterative use.
+
+        Params
+        ------
+        k
+            Key to use. Should be in `.obs_names` or `.var.columns`.
+
+        Returns
+        -------
+        A one dimensional nd array, with values for each var in the same order
+        as `.var_names`.
+        """
+        if k in self.var:
+            a = self.var[k].values
+        else:
+            a = self[k, :].X
+        if issparse(a):
+            a = a.toarray()
+        return np.ravel(a)
+
+    def obs_array(self, k: str) -> np.ndarray:
+        """
+        Convenience function for returning a 1 dimensional ndarray of values
+        from `.X`.
+
+        Made for convenience, not performance. Intentionally permissive about
+        arguments, for easy iterative use.
+
+        Params
+        ------
+        k
+            Key to use. Should be in `.var_names` or `.obs.columns`. If `use_raw`,
+            value should be in `.raw.var_names` instead of `.var_names`.
+
+        Returns
+        -------
+        A one dimensional nd array, with values for each obs in the same order
+        as `.obs_names`.
+        """
+        a = self[:, k].X
+        if issparse(a):
+            a = a.toarray()
+        return np.ravel(a)
+
     @property
     def X(self):
         if self._adata.isbacked:
@@ -1516,7 +1566,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             X = self._X
         return pd.DataFrame(X, index=self.obs_names, columns=self.var_names)
 
-    def _get_expression(self, use_raw=False, layer=None):
+    def _get_X(self, use_raw=False, layer=None):
         """
         Convenience method for getting expression values with common arguments and error handling.
         """
@@ -1536,7 +1586,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             return self.X
 
     def obs_array(
-        self, k: str, *, use_raw: bool = False, layer: Optional[str] = None
+        self, k: str, *, layer: Optional[str] = None
     ) -> np.ndarray:
         """
         Convenience function for returning a 1 dimensional ndarray of values
@@ -1550,8 +1600,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         k
             Key to use. Should be in `.var_names` or `.obs.columns`. If `use_raw`,
             value should be in `.raw.var_names` instead of `.var_names`.
-        use_raw
-            Whether values should be returned from `.raw.X`
         layer
             What layer values should be returned from. If `None`, `.X` is used.
 
@@ -1569,18 +1617,16 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
         if k in self.obs:
             a = self.obs[k].values
-        elif use_raw:
-            a = self.raw[:, k].X
         else:
             idx = self._normalize_indices((slice(None), k))
-            a = self._get_expression(layer=layer)[idx]
+            a = self._get_X(layer=layer)[idx]
         if issparse(a):
-            a = a.toarray().reshape(-1)
-        return a
+            a = a.toarray()
+        return np.ravel(a)
 
 
     def var_array(
-        self, k, *, use_raw: bool = False, layer: Optional[str] = None
+        self, k, *, layer: Optional[str] = None
     ) -> np.ndarray:
         """
         Convenience function for returning a 1 dimensional ndarray of values
@@ -1593,8 +1639,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         ------
         k
             Key to use. Should be in `.obs_names` or `.var.columns`.
-        use_raw
-            Whether values should be returned from `.raw.X`
         layer
             What layer values should be returned from. If `None`, `.X` is used.
 
@@ -1612,14 +1656,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
         if k in self.var:
             a = self.var[k].values
-        elif use_raw:
-            a = self.raw[k, :].X
         else:
             idx = self._normalize_indices((k, slice(None)))
-            a = self._get_expression(layer=layer)[idx]
+            a = self._get_X(layer=layer)[idx]
         if issparse(a):
-            a = a.toarray().reshape(-1)
-        return a
+            a = a.toarray()
+        return np.ravel(a)
 
     @utils.deprecated("obs_array")
     def _get_obs_array(self, k, use_raw=False, layer=None):

--- a/anndata/base.py
+++ b/anndata/base.py
@@ -535,7 +535,7 @@ class Raw:
         var = _normalize_index(var, self.var_names)
         return obs, var
 
-    def get_var_slice_1d(self, k: str) -> np.ndarray:
+    def var_vector(self, k: str) -> np.ndarray:
         """
         Convenience function for returning a 1 dimensional ndarray of values
         from `.X` or `.var`.
@@ -561,7 +561,7 @@ class Raw:
             a = a.toarray()
         return np.ravel(a)
 
-    def get_obs_slice_1d(self, k: str) -> np.ndarray:
+    def obs_vector(self, k: str) -> np.ndarray:
         """
         Convenience function for returning a 1 dimensional ndarray of values
         from `.X`.
@@ -1585,7 +1585,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         else:
             return self.X
 
-    def get_obs_slice_1d(
+    def obs_vector(
         self, k: str, *, layer: Optional[str] = None
     ) -> np.ndarray:
         """
@@ -1624,7 +1624,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         return np.ravel(a)
 
 
-    def get_var_slice_1d(
+    def var_vector(
         self, k, *, layer: Optional[str] = None
     ) -> np.ndarray:
         """
@@ -1662,17 +1662,17 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             a = a.toarray()
         return np.ravel(a)
 
-    @utils.deprecated("get_obs_slice_1d")
+    @utils.deprecated("obs_vector")
     def _get_obs_array(self, k, use_raw=False, layer=None):
         """Get an array from the layer (default layer='X') along the observation dimension by first looking up
         obs.keys and then var.index."""
-        return self.get_obs_slice_1d(k=k, use_raw=use_raw, layer=layer)
+        return self.obs_vector(k=k, use_raw=use_raw, layer=layer)
 
-    @utils.deprecated("get_var_slice_1d")
+    @utils.deprecated("var_vector")
     def _get_var_array(self, k, use_raw=False, layer='X'):
         """Get an array from the layer (default layer='X') along the variables dimension by first looking up
         ``var.keys`` and then ``obs.index``."""
-        return self.get_var_slice_1d(k=k, use_raw=use_raw, layer=layer)
+        return self.var_vector(k=k, use_raw=use_raw, layer=layer)
 
     def copy(self, filename: Optional[PathLike] = None) -> 'AnnData':
         """Full copy, optionally on disk."""

--- a/anndata/base.py
+++ b/anndata/base.py
@@ -462,7 +462,7 @@ class Raw:
             self._var = adata.var.copy()
             self._varm = adata.varm.copy()
 
-    def var_array(self, k: str) -> np.ndarray:
+    def get_var_slice_1d(self, k: str) -> np.ndarray:
         """
         Convenience function for returning a 1 dimensional ndarray of values
         from `.X` or `.var`.
@@ -488,7 +488,7 @@ class Raw:
             a = a.toarray()
         return np.ravel(a)
 
-    def obs_array(self, k: str) -> np.ndarray:
+    def get_obs_slice_1d(self, k: str) -> np.ndarray:
         """
         Convenience function for returning a 1 dimensional ndarray of values
         from `.X`.
@@ -1585,12 +1585,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         else:
             return self.X
 
-    def obs_array(
+    def get_obs_slice_1d(
         self, k: str, *, layer: Optional[str] = None
     ) -> np.ndarray:
         """
         Convenience function for returning a 1 dimensional ndarray of values
-        from `.X`, `.raw.X`, `.layers[k]`, or `.obs`.
+        from `.X`, `.layers[k]`, or `.obs`.
 
         Made for convenience, not performance. Intentionally permissive about
         arguments, for easy iterative use.
@@ -1598,8 +1598,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         Params
         ------
         k
-            Key to use. Should be in `.var_names` or `.obs.columns`. If `use_raw`,
-            value should be in `.raw.var_names` instead of `.var_names`.
+            Key to use. Should be in `.var_names` or `.obs.columns`.
         layer
             What layer values should be returned from. If `None`, `.X` is used.
 
@@ -1625,12 +1624,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         return np.ravel(a)
 
 
-    def var_array(
+    def get_var_slice_1d(
         self, k, *, layer: Optional[str] = None
     ) -> np.ndarray:
         """
         Convenience function for returning a 1 dimensional ndarray of values
-        from `.X`, `.raw.X`, `.layers[k]`, or `.obs`.
+        from `.X`, `.layers[k]`, or `.obs`.
 
         Made for convenience, not performance. Intentionally permissive about
         arguments, for easy iterative use.
@@ -1663,17 +1662,17 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             a = a.toarray()
         return np.ravel(a)
 
-    @utils.deprecated("obs_array")
+    @utils.deprecated("get_obs_slice_1d")
     def _get_obs_array(self, k, use_raw=False, layer=None):
         """Get an array from the layer (default layer='X') along the observation dimension by first looking up
         obs.keys and then var.index."""
-        return self.obs_array(k=k, use_raw=use_raw, layer=layer)
+        return self.get_obs_slice_1d(k=k, use_raw=use_raw, layer=layer)
 
-    @utils.deprecated("var_array")
+    @utils.deprecated("get_var_slice_1d")
     def _get_var_array(self, k, use_raw=False, layer='X'):
         """Get an array from the layer (default layer='X') along the variables dimension by first looking up
         ``var.keys`` and then ``obs.index``."""
-        return self.var_array(k=k, use_raw=use_raw, layer=layer)
+        return self.get_var_slice_1d(k=k, use_raw=use_raw, layer=layer)
 
     def copy(self, filename: Optional[PathLike] = None) -> 'AnnData':
         """Full copy, optionally on disk."""

--- a/anndata/base.py
+++ b/anndata/base.py
@@ -462,56 +462,6 @@ class Raw:
             self._var = adata.var.copy()
             self._varm = adata.varm.copy()
 
-    def get_var_slice_1d(self, k: str) -> np.ndarray:
-        """
-        Convenience function for returning a 1 dimensional ndarray of values
-        from `.X` or `.var`.
-
-        Made for convenience, not performance. Intentionally permissive about
-        arguments, for easy iterative use.
-
-        Params
-        ------
-        k
-            Key to use. Should be in `.obs_names` or `.var.columns`.
-
-        Returns
-        -------
-        A one dimensional nd array, with values for each var in the same order
-        as `.var_names`.
-        """
-        if k in self.var:
-            a = self.var[k].values
-        else:
-            a = self[k, :].X
-        if issparse(a):
-            a = a.toarray()
-        return np.ravel(a)
-
-    def get_obs_slice_1d(self, k: str) -> np.ndarray:
-        """
-        Convenience function for returning a 1 dimensional ndarray of values
-        from `.X`.
-
-        Made for convenience, not performance. Intentionally permissive about
-        arguments, for easy iterative use.
-
-        Params
-        ------
-        k
-            Key to use. Should be in `.var_names` or `.obs.columns`. If `use_raw`,
-            value should be in `.raw.var_names` instead of `.var_names`.
-
-        Returns
-        -------
-        A one dimensional nd array, with values for each obs in the same order
-        as `.obs_names`.
-        """
-        a = self[:, k].X
-        if issparse(a):
-            a = a.toarray()
-        return np.ravel(a)
-
     @property
     def X(self):
         if self._adata.isbacked:
@@ -584,6 +534,56 @@ class Raw:
         obs = _normalize_index(obs, self._adata.obs_names)
         var = _normalize_index(var, self.var_names)
         return obs, var
+
+    def get_var_slice_1d(self, k: str) -> np.ndarray:
+        """
+        Convenience function for returning a 1 dimensional ndarray of values
+        from `.X` or `.var`.
+
+        Made for convenience, not performance. Intentionally permissive about
+        arguments, for easy iterative use.
+
+        Params
+        ------
+        k
+            Key to use. Should be in `.obs_names` or `.var.columns`.
+
+        Returns
+        -------
+        A one dimensional nd array, with values for each var in the same order
+        as `.var_names`.
+        """
+        if k in self.var:
+            return self.var[k].values
+        else:
+            a = self[k, :].X
+        if issparse(a):
+            a = a.toarray()
+        return np.ravel(a)
+
+    def get_obs_slice_1d(self, k: str) -> np.ndarray:
+        """
+        Convenience function for returning a 1 dimensional ndarray of values
+        from `.X`.
+
+        Made for convenience, not performance. Intentionally permissive about
+        arguments, for easy iterative use.
+
+        Params
+        ------
+        k
+            Key to use. Should be in `.var_names` or `.obs.columns`. If `use_raw`,
+            value should be in `.raw.var_names` instead of `.var_names`.
+
+        Returns
+        -------
+        A one dimensional nd array, with values for each obs in the same order
+        as `.obs_names`.
+        """
+        a = self[:, k].X
+        if issparse(a):
+            a = a.toarray()
+        return np.ravel(a)
 
 
 INDEX_DIM_ERROR_MSG = 'You tried to slice an AnnData(View) object with an' \
@@ -1615,7 +1615,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 layer = None
 
         if k in self.obs:
-            a = self.obs[k].values
+            return self.obs[k].values
         else:
             idx = self._normalize_indices((slice(None), k))
             a = self._get_X(layer=layer)[idx]

--- a/anndata/layers.py
+++ b/anndata/layers.py
@@ -44,6 +44,9 @@ class AnnDataLayers:
         else:
             return self._layers[key]
 
+    def __contains__(self, key):
+        return key in self._layers
+
     def __setitem__(self, key, value):
         if not isinstance(value, np.ndarray) and not issparse(value):
             raise ValueError('Value should be numpy array or sparse matrix')

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -514,10 +514,12 @@ def test_1d_slice_dtypes():
     new_obs_df = pd.DataFrame(index=adata.obs_names)
     for k in obs_df.columns:
         new_obs_df[k] = adata.get_obs_slice_1d(k)
+        new_obs_df[k].dtype is obs_df[k].dtype
     assert np.all(new_obs_df == obs_df)
     new_var_df = pd.DataFrame(index=adata.var_names)
     for k in var_df.columns:
         new_var_df[k] = adata.get_var_slice_1d(k)
+        new_var_df[k].dtype is var_df[k].dtype
     assert np.all(new_var_df == var_df)
 
 

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -1,5 +1,4 @@
 from itertools import product
-from functools import partial
 
 import numpy as np
 from numpy import ma
@@ -183,7 +182,7 @@ def test_slicing_strings():
     with raises(IndexError): _ = adata['X', :]
     with raises(IndexError): _ = adata['A':'X', :]
     with raises(IndexError): _ = adata[:, 'a':'X']
-    
+
     # Test if errors are helpful
     with raises(KeyError, match=r"not_in_var"):
         adata[:, ["A", "B", "not_in_var"]]
@@ -469,7 +468,7 @@ def test_convenience():
             adata, adata_dense,
             lambda x: x.obs_vector(obs_k, layer=layer)
         )
-    
+
     for obs_k in ["a", "b", "c"]:
         assert_same_op_result(
             adata, adata_dense,
@@ -481,7 +480,7 @@ def test_convenience():
             adata, adata_dense,
             lambda x: x.var_vector(var_k, layer=layer)
         )
-    
+
     for var_k in ["s1", "s2", "anno2"]:
         assert_same_op_result(
             adata, adata_dense,

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -458,28 +458,34 @@ def test_convenience():
         assert np.all(r1 == r2)
         assert type(r1) == type(r2)
 
-    assert np.allclose(adata.obs_array("b"), np.array([1., 2.5]))
-    assert np.allclose(adata.raw.obs_array("c"), np.array([3, 6]))
-    assert np.all(adata.obs_array("anno1") == np.array(["c1", "c2"]))
-    assert np.allclose(adata.var_array("s1"), np.array([0, 1., 1.5]))
-    assert np.allclose(adata.raw.var_array("s2"), np.array([0, 5, 6]))
+    assert np.allclose(adata.get_obs_slice_1d("b"), np.array([1., 2.5]))
+    assert np.allclose(adata.raw.get_obs_slice_1d("c"), np.array([3, 6]))
+    assert np.all(adata.get_obs_slice_1d("anno1") == np.array(["c1", "c2"]))
+    assert np.allclose(adata.get_var_slice_1d("s1"), np.array([0, 1., 1.5]))
+    assert np.allclose(adata.raw.get_var_slice_1d("s2"), np.array([0, 5, 6]))
 
-    for obs_k in ["a", "b", "c", "anno1"]:
+    for obs_k, layer in product(["a", "b", "c", "anno1"], [None, "x2"]):
         assert_same_op_result(
             adata, adata_dense,
-            lambda x: x.obs_array(obs_k)
+            lambda x: x.get_obs_slice_1d(obs_k, layer=layer)
         )
     
     for obs_k in ["a", "b", "c"]:
         assert_same_op_result(
             adata, adata_dense,
-            lambda x: x.raw.obs_array(obs_k)
+            lambda x: x.raw.get_obs_slice_1d(obs_k)
         )
 
     for var_k, layer in product(["s1", "s2", "anno2"], [None, "x2"]):
         assert_same_op_result(
             adata, adata_dense,
-            lambda x: x.obs_array(obs_k, layer=layer)
+            lambda x: x.get_var_slice_1d(var_k, layer=layer)
+        )
+    
+    for var_k in ["s1", "s2", "anno2"]:
+        assert_same_op_result(
+            adata, adata_dense,
+            lambda x: x.raw.get_var_slice_1d(var_k)
         )
 
 

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -1,4 +1,5 @@
 from itertools import product
+from functools import partial
 
 import numpy as np
 from numpy import ma
@@ -443,30 +444,43 @@ def test_to_df_dense():
 
 
 def test_convenience():
-    # Setup
     adata = adata_sparse.copy()
+    adata.layers["x2"] = adata.X * 2
     adata.var["anno2"] = ["p1", "p2", "p3"]
     adata.raw = adata
     adata.X = adata.X / 2
     adata_dense = adata.copy()
     adata_dense.X = adata_dense.X.toarray()
 
+    def assert_same_op_result(a1, a2, op):
+        r1 = op(a1)
+        r2 = op(a2)
+        assert np.all(r1 == r2)
+        assert type(r1) == type(r2)
+
     assert np.allclose(adata.obs_array("b"), np.array([1., 2.5]))
-    assert np.allclose(adata.obs_array("c", use_raw=True), np.array([3, 6]))
+    assert np.allclose(adata.raw.obs_array("c"), np.array([3, 6]))
     assert np.all(adata.obs_array("anno1") == np.array(["c1", "c2"]))
     assert np.allclose(adata.var_array("s1"), np.array([0, 1., 1.5]))
-    assert np.allclose(adata.var_array("s2", use_raw=True), np.array([0, 5, 6]))
+    assert np.allclose(adata.raw.var_array("s2"), np.array([0, 5, 6]))
 
-    for obs_k, use_raw in product(["a", "b", "c", "anno1"], [True, False]):
-        r1 = adata.obs_array(obs_k, use_raw=use_raw)
-        r2 = adata_dense.obs_array(obs_k, use_raw=use_raw)
-        assert np.all(r1 == r2)
-        assert type(r1) == type(r2)
-    for var_k, use_raw in product(["s1", "s2", "anno2"], [True, False]):
-        r1 = adata.var_array(var_k, use_raw=use_raw)
-        r2 = adata_dense.var_array(var_k, use_raw=use_raw)
-        assert np.all(r1 == r2)
-        assert type(r1) == type(r2)
+    for obs_k in ["a", "b", "c", "anno1"]:
+        assert_same_op_result(
+            adata, adata_dense,
+            lambda x: x.obs_array(obs_k)
+        )
+    
+    for obs_k in ["a", "b", "c"]:
+        assert_same_op_result(
+            adata, adata_dense,
+            lambda x: x.raw.obs_array(obs_k)
+        )
+
+    for var_k, layer in product(["s1", "s2", "anno2"], [None, "x2"]):
+        assert_same_op_result(
+            adata, adata_dense,
+            lambda x: x.obs_array(obs_k, layer=layer)
+        )
 
 
 def test_to_df_sparse():

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -458,34 +458,34 @@ def test_convenience():
         assert np.all(r1 == r2)
         assert type(r1) == type(r2)
 
-    assert np.allclose(adata.get_obs_slice_1d("b"), np.array([1., 2.5]))
-    assert np.allclose(adata.raw.get_obs_slice_1d("c"), np.array([3, 6]))
-    assert np.all(adata.get_obs_slice_1d("anno1") == np.array(["c1", "c2"]))
-    assert np.allclose(adata.get_var_slice_1d("s1"), np.array([0, 1., 1.5]))
-    assert np.allclose(adata.raw.get_var_slice_1d("s2"), np.array([0, 5, 6]))
+    assert np.allclose(adata.obs_vector("b"), np.array([1., 2.5]))
+    assert np.allclose(adata.raw.obs_vector("c"), np.array([3, 6]))
+    assert np.all(adata.obs_vector("anno1") == np.array(["c1", "c2"]))
+    assert np.allclose(adata.var_vector("s1"), np.array([0, 1., 1.5]))
+    assert np.allclose(adata.raw.var_vector("s2"), np.array([0, 5, 6]))
 
     for obs_k, layer in product(["a", "b", "c", "anno1"], [None, "x2"]):
         assert_same_op_result(
             adata, adata_dense,
-            lambda x: x.get_obs_slice_1d(obs_k, layer=layer)
+            lambda x: x.obs_vector(obs_k, layer=layer)
         )
     
     for obs_k in ["a", "b", "c"]:
         assert_same_op_result(
             adata, adata_dense,
-            lambda x: x.raw.get_obs_slice_1d(obs_k)
+            lambda x: x.raw.obs_vector(obs_k)
         )
 
     for var_k, layer in product(["s1", "s2", "anno2"], [None, "x2"]):
         assert_same_op_result(
             adata, adata_dense,
-            lambda x: x.get_var_slice_1d(var_k, layer=layer)
+            lambda x: x.var_vector(var_k, layer=layer)
         )
     
     for var_k in ["s1", "s2", "anno2"]:
         assert_same_op_result(
             adata, adata_dense,
-            lambda x: x.raw.get_var_slice_1d(var_k)
+            lambda x: x.raw.var_vector(var_k)
         )
 
 
@@ -513,12 +513,12 @@ def test_1d_slice_dtypes():
 
     new_obs_df = pd.DataFrame(index=adata.obs_names)
     for k in obs_df.columns:
-        new_obs_df[k] = adata.get_obs_slice_1d(k)
+        new_obs_df[k] = adata.obs_vector(k)
         new_obs_df[k].dtype is obs_df[k].dtype
     assert np.all(new_obs_df == obs_df)
     new_var_df = pd.DataFrame(index=adata.var_names)
     for k in var_df.columns:
-        new_var_df[k] = adata.get_var_slice_1d(k)
+        new_var_df[k] = adata.var_vector(k)
         new_var_df[k].dtype is var_df[k].dtype
     assert np.all(new_var_df == var_df)
 

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -455,7 +455,7 @@ def test_convenience():
         r1 = op(a1)
         r2 = op(a2)
         assert np.all(r1 == r2)
-        assert type(r1) == type(r2)
+        assert type(r1) is type(r2)
 
     assert np.allclose(adata.obs_vector("b"), np.array([1., 2.5]))
     assert np.allclose(adata.raw.obs_vector("c"), np.array([3, 6]))
@@ -513,12 +513,12 @@ def test_1d_slice_dtypes():
     new_obs_df = pd.DataFrame(index=adata.obs_names)
     for k in obs_df.columns:
         new_obs_df[k] = adata.obs_vector(k)
-        new_obs_df[k].dtype is obs_df[k].dtype
+        assert new_obs_df[k].dtype is obs_df[k].dtype
     assert np.all(new_obs_df == obs_df)
     new_var_df = pd.DataFrame(index=adata.var_names)
     for k in var_df.columns:
         new_var_df[k] = adata.var_vector(k)
-        new_var_df[k].dtype is var_df[k].dtype
+        assert new_var_df[k].dtype is var_df[k].dtype
     assert np.all(new_var_df == var_df)
 
 

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -489,6 +489,38 @@ def test_convenience():
         )
 
 
+def test_1d_slice_dtypes():
+    N, M = 10, 20
+    obs_df = pd.DataFrame(
+        {
+            "cat": pd.Categorical(np.arange(N, dtype=int)),
+            "int": np.arange(N, dtype=int),
+            "float": np.arange(N, dtype=float),
+            "obj": [str(i) for i in np.arange(N, dtype=int)]
+        },
+        index=["cell{}".format(i) for i in np.arange(N, dtype=int)]
+    )
+    var_df = pd.DataFrame(
+        {
+            "cat": pd.Categorical(np.arange(M, dtype=int)),
+            "int": np.arange(M, dtype=int),
+            "float": np.arange(M, dtype=float),
+            "obj": [str(i) for i in np.arange(M, dtype=int)]
+        },
+        index=["gene{}".format(i) for i in np.arange(M, dtype=int)]
+    )
+    adata = AnnData(X=np.random.random((N, M)), obs=obs_df, var=var_df)
+
+    new_obs_df = pd.DataFrame(index=adata.obs_names)
+    for k in obs_df.columns:
+        new_obs_df[k] = adata.get_obs_slice_1d(k)
+    assert np.all(new_obs_df == obs_df)
+    new_var_df = pd.DataFrame(index=adata.var_names)
+    for k in var_df.columns:
+        new_var_df[k] = adata.get_var_slice_1d(k)
+    assert np.all(new_var_df == var_df)
+
+
 def test_to_df_sparse():
     X = adata_sparse.X.toarray()
     df = adata_sparse.to_df()

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -1,3 +1,5 @@
+from itertools import product
+
 import numpy as np
 from numpy import ma
 import pandas as pd
@@ -438,6 +440,33 @@ def test_pickle():
 
 def test_to_df_dense():
     df = adata_dense.to_df()
+
+
+def test_convenience():
+    # Setup
+    adata = adata_sparse.copy()
+    adata.var["anno2"] = ["p1", "p2", "p3"]
+    adata.raw = adata
+    adata.X = adata.X / 2
+    adata_dense = adata.copy()
+    adata_dense.X = adata_dense.X.toarray()
+
+    assert np.allclose(adata.obs_array("b"), np.array([1., 2.5]))
+    assert np.allclose(adata.obs_array("c", use_raw=True), np.array([3, 6]))
+    assert np.all(adata.obs_array("anno1") == np.array(["c1", "c2"]))
+    assert np.allclose(adata.var_array("s1"), np.array([0, 1., 1.5]))
+    assert np.allclose(adata.var_array("s2", use_raw=True), np.array([0, 5, 6]))
+
+    for obs_k, use_raw in product(["a", "b", "c", "anno1"], [True, False]):
+        r1 = adata.obs_array(obs_k, use_raw=use_raw)
+        r2 = adata_dense.obs_array(obs_k, use_raw=use_raw)
+        assert np.all(r1 == r2)
+        assert type(r1) == type(r2)
+    for var_k, use_raw in product(["s1", "s2", "anno2"], [True, False]):
+        r1 = adata.var_array(var_k, use_raw=use_raw)
+        r2 = adata_dense.var_array(var_k, use_raw=use_raw)
+        assert np.all(r1 == r2)
+        assert type(r1) == type(r2)
 
 
 def test_to_df_sparse():

--- a/anndata/tests/test_deprecations.py
+++ b/anndata/tests/test_deprecations.py
@@ -1,0 +1,79 @@
+"""This file contains tests for deprecated functions.
+
+This includes correct behaviour as well as throwing warnings.
+"""
+import numpy as np
+import pytest
+from scipy.sparse import csr_matrix
+
+from anndata import AnnData
+
+
+@pytest.fixture
+def adata():
+    adata = AnnData(
+        X=csr_matrix([[0, 2, 3], [0, 5, 6]]),
+        obs={
+            'obs_names': ['s1', 's2'],
+            'anno1': ['c1', 'c2']
+        },
+        var={'var_names': ['a', 'b', 'c']}
+    )
+    adata.raw = adata
+    adata.layers["x2"] = adata.X * 2
+    adata.var["anno2"] = ["p1", "p2", "p3"]
+    adata.X = adata.X / 2
+    return adata
+
+
+def test_get_obsvar_array_warn(adata):
+    with pytest.warns(DeprecationWarning):
+        adata._get_obs_array("a")
+    with pytest.warns(DeprecationWarning):
+        adata._get_var_array("s1")
+
+
+def test_get_obsvar_array(adata):
+    assert np.allclose(
+        adata._get_obs_array("a"),
+        adata.obs_vector("a")
+    )
+    assert np.allclose(
+        adata._get_obs_array("a", layer="x2"),
+        adata.obs_vector("a", layer="x2")
+    )
+    assert np.allclose(
+        adata._get_obs_array("a", use_raw=True),
+        adata.raw.obs_vector("a")
+    )
+    assert np.allclose(
+        adata._get_var_array("s1"),
+        adata.var_vector("s1")
+    )
+    assert np.allclose(
+        adata._get_var_array("s1", layer="x2"),
+        adata.var_vector("s1", layer="x2")
+    )
+    assert np.allclose(
+        adata._get_var_array("s1", use_raw=True),
+        adata.raw.var_vector("s1")
+    )
+
+
+def test_obsvar_vector_Xlayer(adata):
+    with pytest.warns(FutureWarning):
+        adata.var_vector("s1", layer="X")
+    with pytest.warns(FutureWarning):
+        adata.obs_vector("a", layer="X")
+
+    adata = adata.copy()
+    adata.layers["X"] = adata.X * 3
+
+    with pytest.warns(None) as records:
+        adata.var_vector("s1", layer="X")
+        adata.obs_vector("a", layer="X")
+
+    for r in records:
+        # This time it shouldn't throw a warning
+        if "anndata" in r.filename:
+            assert r.category is not FutureWarning

--- a/anndata/tests/test_layers.py
+++ b/anndata/tests/test_layers.py
@@ -22,6 +22,9 @@ def test_creation():
     adata = ad.AnnData(X=X, layers={'L': L.copy()})
 
     assert list(adata.layers.keys()) == ['L']
+    assert "L" in adata.layers
+    assert "X" not in adata.layers
+    assert "some_other_thing" not in adata.layers
     assert (adata.layers['L'] == L).all()
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import sys
 if sys.version_info < (3,):
-    sys.exit('anndata requires Python >= 3.5')
+    sys.exit('anndata requires Python >= 3.6')
 from pathlib import Path
 
 from setuptools import setup, find_packages
@@ -25,7 +25,7 @@ setup(
         l.strip() for l in
         Path('requirements.txt').read_text('utf-8').splitlines()
     ],
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     packages=find_packages(),
     zip_safe=False,
     classifiers=[
@@ -38,7 +38,6 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
         'Topic :: Scientific/Engineering :: Visualization',


### PR DESCRIPTION
Convenience functions for retrieving an array of values along either the `obs` or `var` dimension.

A proposed update to `_get_{obs,var}_array` as discussed with @falexwolf in theislab/scanpy#619.

As I was writing it, it got more complicated that I expected (of course). I think `use_raw` may be poorly posed here, unless it's meant to only refer to `.raw.X`. For `var_array(..., use_raw=True)`, how many values should be returned? `adata.shape[1]` or `adata.raw.shape[1]`? Should we only check `adata.raw.var` for keys? This would change `_get_var_array`'s current behavior: https://github.com/theislab/anndata/blob/34f4eb63710628fbc15e7050e5efcac1d7806062/anndata/base.py#L1488-L1510