### PR TITLE
update syntax for importing Mapping from collections.abc

### DIFF
--- a/anndata/readwrite/write.py
+++ b/anndata/readwrite/write.py
@@ -1,5 +1,5 @@
 import warnings
-from collections import Mapping
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Union, MutableMapping
 


### PR DESCRIPTION
Without this change, I get the following warning:
```
/home/jeff/miniconda3/lib/python3.7/site-packages/anndata/readwrite/write.py:2
  /home/jeff/miniconda3/lib/python3.7/site-packages/anndata/readwrite/write.py:2: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping
```