### PR TITLE
[Suggestion] Run travis with scipy 1.2 and 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 dist: xenial
 language: python
 cache: pip
+env: # Temporarily run tests agains multiple versions of scipy
+  - SCIPY_VERSION=1.2.1
+  - SCIPY_VERSION=1.3.0
 python:
   - "3.6"
   - "3.7"
 install:
+  - "pip install scipy==$SCIPY_VERSION"
   - "pip install -r requirements.txt"
   - "pip install -r requirements_tests.txt"
   - "pip install docutils"


### PR DESCRIPTION
Until we can set scanpy to work with scipy 1.3, I think we should test against scipy 1.2 and 1.3. Especially since sparse matrices changed so much.