### PR TITLE
Views of views

### DIFF
--- a/anndata/core/alignedmapping.py
+++ b/anndata/core/alignedmapping.py
@@ -119,12 +119,12 @@ class AlignedViewMixin:
     isview = True
 
     def __getitem__(self, key):
-        return _subset(
-            asview(
+        return asview(
+            _subset(
                 self.parent_mapping[key],
-                ViewArgs(self.parent, self.attrname, (key,))
+                self.subset_idx
             ),
-            self.subset_idx
+            ViewArgs(self.parent, self.attrname, (key,))
         )
 
     def __setitem__(self, key, value):
@@ -247,6 +247,13 @@ class LayersBase(AlignedMapping):
     """
     attrname = "layers"
     axes = (0, 1)
+
+    # TODO: I thought I had a more elegant solution to overiding this...
+    def copy(self):
+        d = self._actual_class(self.parent)
+        for k, v in self.items():
+            d[k] = v.copy()
+        return d
 
 
 class Layers(AlignedActualMixin, LayersBase):

--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -819,13 +819,14 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             )
         else:
             X = self._X
-        if self.n_obs == 1 and self.n_vars == 1:
-            return X[0, 0]
-        elif self.n_obs == 1 or self.n_vars == 1:
-            if issparse(X): X = X.toarray()
-            return X.flatten()
-        else:
-            return X
+        return X
+        # if self.n_obs == 1 and self.n_vars == 1:
+        #     return X[0, 0]
+        # elif self.n_obs == 1 or self.n_vars == 1:
+        #     if issparse(X): X = X.toarray()
+        #     return X.flatten()
+        # else:
+        #     return X
 
 
     @X.setter
@@ -1298,6 +1299,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             dfs = [self.obs, self.var]
             if self.isview:
                 if not self.isbacked:
+                    warnings.warn("Initializing view as actual.")
                     self._init_as_actual(self.copy())
                 else:
                     dont_modify = True

--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -15,7 +15,7 @@ import numpy as np
 from numpy import ma
 import pandas as pd
 from pandas.core.index import RangeIndex
-from pandas.api.types import is_string_dtype, is_categorical, is_integer_dtype
+from pandas.api.types import is_string_dtype, is_categorical
 from scipy import sparse
 from scipy.sparse import issparse
 from natsort import natsorted
@@ -848,7 +848,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         else:
             X = self._X
         if self.n_obs == 1 and self.n_vars == 1:
-            return self._X[0, 0]
             return X[0, 0]
         elif self.n_obs == 1 or self.n_vars == 1:
             if issparse(X): X = X.toarray()

--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -810,12 +810,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             if self.isview:
                 X = X[self._oidx, self._vidx]
         elif self.isview:
-            X = _subset(
-                asview(
+            X = asview(
+                _subset(
                     self._adata_ref.X,
-                    ViewArgs(self._adata_ref, "X")
+                    (self._oidx, self._vidx)
                 ),
-                (self._oidx, self._vidx)
+                ViewArgs(self._adata_ref, "X")
             )
         else:
             X = self._X
@@ -1546,7 +1546,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                            self.uns.copy() if isinstance(self.uns, DictView) else deepcopy(self.uns),
                            self.obsm.copy(), self.varm.copy(),
                            raw=None if self._raw is None else self._raw.copy(),
-                           layers=dict(self.layers),
+                           layers=self.layers.copy(),
                            dtype=self.X.dtype.name if self.X is not None else 'float32')
         else:
             if filename is None:

--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -607,23 +607,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         # need to do the slicing before setting the updated self._n_obs, self._n_vars
         self._n_obs = self._adata_ref.n_obs  # use the original n_obs here
         self._slice_uns_sparse_matrices_inplace(uns_new, self._oidx)
-        # fix _n_obs, _n_vars
-        if isinstance(oidx, slice):
-            self._n_obs = get_n_items_idx(obs_sub.index, adata_ref.n_obs)
-        elif isinstance(oidx, (int, np.integer)):
-            self._n_obs = 1
-        elif isinstance(oidx, Sized):
-            self._n_obs = get_n_items_idx(oidx, adata_ref.n_obs)
-        else:
-            raise KeyError('Unknown Index type')
-        if isinstance(vidx, slice):
-            self._n_vars = get_n_items_idx(var_sub.index, adata_ref.n_vars)
-        elif isinstance(vidx, (int, np.integer)):
-            self._n_vars = 1
-        elif isinstance(vidx, Sized):
-            self._n_vars = get_n_items_idx(vidx, adata_ref.n_vars)
-        else:
-            raise KeyError('Unknown Index type')
         # fix categories
         self._remove_unused_categories(adata_ref.obs, obs_sub, uns_new)
         self._remove_unused_categories(adata_ref.var, var_sub, uns_new)
@@ -631,6 +614,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         self._obs = DataFrameView(obs_sub, view_args=(self, 'obs'))
         self._var = DataFrameView(var_sub, view_args=(self, 'var'))
         self._uns = DictView(uns_new, view_args=(self, 'uns'))
+        self._n_obs = len(self.obs)
+        self._n_vars = len(self.var)
+
         # set data
         if self.isbacked:
             self._X = None

--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -526,6 +526,19 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
     If the unstructured annotations :attr:`uns` contain a sparse matrix of shape
     :attr:`n_obs` × :attr:`n_obs`, these are subset with the observation dimension.
 
+    Subsetting an AnnData object returns a view into the original object, meaning very little
+    additional memory is used upon subsetting. This is achieved through laziness, meaning
+    subsetting the constituent arrays is deferred until they are accessed. Copying a view causes
+    an equivalent "real" AnnData object to be generated. Attempting to modify a view (at any attribute
+    except X) is handled in a copy-on-modify manner, meaning the object is initialized in place.
+    Here's an example::
+
+        batch1 = adata[adata.obs["batch"] == "batch1", :]
+        batch1.obs["value"] = 0  # This makes batch1 a "real" anndata object, with it's own data
+
+    At the end of this snippet: `adata` was not modified, and `batch1` is it's own AnnData object
+    with it's own data.
+
     Similar to Bioconductor's `ExpressionSet`, subsetting an AnnData object doesn't reduce the
     dimensions of it's constituent arrays. This differs from behaviour of libraries like `pandas`,
     `numpy`, and `xarray`. However, unlike the classes exposed by those libraries, there is no

--- a/anndata/core/views.py
+++ b/anndata/core/views.py
@@ -76,6 +76,7 @@ class ArrayView(_SetItemMixin, np.ndarray):
         return self.copy()
 
 
+# Unlike array views, SparseCSRView and SparseCSCView do not propagate through subsetting
 class SparseCSRView(_ViewMixin, sparse.csr_matrix):
     pass
 

--- a/anndata/core/views.py
+++ b/anndata/core/views.py
@@ -130,12 +130,8 @@ def _resolve_idx(old, new, l):
 
 @_resolve_idx.register(np.ndarray)
 def _resolve_idx_ndarray(old, new, l):
-    if is_bool_dtype(old) and is_bool_dtype(new):
-        return old & new
-    elif is_bool_dtype(old):
+    if is_bool_dtype(old):
         old = np.where(old)[0]
-    elif is_bool_dtype(new):
-        new = np.where(new)[0]
     return old[new]
 
 @_resolve_idx.register(np.integer)

--- a/anndata/core/views.py
+++ b/anndata/core/views.py
@@ -119,12 +119,9 @@ def asview_dict(d, view_args):
     return DictView(d, view_args=view_args)
 
 def _resolve_idxs(old, new, adata):
-    print("old", old)
-    print("new", new)
     t = tuple(
         _resolve_idx(old[i], new[i], adata.shape[i]) for i in (0, 1)
     )
-    print(t)
     return t
 
 @singledispatch

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -135,7 +135,6 @@ def array_subset(index, min_size=2):
         raise ValueError(
             f"min_size (={min_size}) must be smaller than len(index) (={len(index)}"
         )
-    print(index)
     return np.random.choice(
         index,
         size=np.random.randint(min_size, len(index), ()),

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -128,6 +128,13 @@ def array_subset(index):
         replace=False
     )
 
+def array_int_subset(index):
+    return np.random.choice(
+        np.arange(len(index)),
+        size=np.random.randint(2, len(index), ()),
+        replace=False
+    )
+
 def slice_subset(index):
     points = np.random.choice(np.arange(len(index)), size=2, replace=False)
     return slice(*sorted(points))
@@ -136,6 +143,6 @@ def single_subset(index):
     return index[np.random.randint(0, len(index), size=())]
 
 
-@pytest.fixture(params=[array_subset, slice_subset, single_subset])
+@pytest.fixture(params=[array_subset, slice_subset, single_subset, array_int_subset])
 def subset_func(request):
     return request.param

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -120,6 +120,15 @@ def gen_adata(
     )
     return adata
 
+def array_bool_subset(index, min_size=2):
+    b = np.zeros(len(index), dtype=bool)
+    selected = np.random.choice(
+        range(len(index)), 
+        size=np.random.randint(min_size, len(index), ()),
+        replace=False
+    )
+    b[selected] = True
+    return b
 
 def array_subset(index, min_size=2):
     if len(index) < min_size:
@@ -156,6 +165,6 @@ def single_subset(index):
     return index[np.random.randint(0, len(index), size=())]
 
 
-@pytest.fixture(params=[array_subset, slice_subset, single_subset, array_int_subset])
+@pytest.fixture(params=[array_subset, slice_subset, single_subset, array_int_subset, array_bool_subset])
 def subset_func(request):
     return request.param

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -123,7 +123,7 @@ def gen_adata(
 def array_bool_subset(index, min_size=2):
     b = np.zeros(len(index), dtype=bool)
     selected = np.random.choice(
-        range(len(index)), 
+        range(len(index)),
         size=np.random.randint(min_size, len(index), ()),
         replace=False
     )

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -121,23 +121,36 @@ def gen_adata(
     return adata
 
 
-def array_subset(index):
+def array_subset(index, min_size=2):
+    if len(index) < min_size:
+        raise ValueError(
+            f"min_size (={min_size}) must be smaller than len(index) (={len(index)}"
+        )
+    print(index)
     return np.random.choice(
         index,
-        size=np.random.randint(2, len(index), ()),
+        size=np.random.randint(min_size, len(index), ()),
         replace=False
     )
 
-def array_int_subset(index):
+def array_int_subset(index, min_size=2):
+    if len(index) < min_size:
+        raise ValueError(
+            f"min_size (={min_size}) must be smaller than len(index) (={len(index)}"
+        )
     return np.random.choice(
         np.arange(len(index)),
-        size=np.random.randint(2, len(index), ()),
+        size=np.random.randint(min_size, len(index), ()),
         replace=False
     )
 
-def slice_subset(index):
-    points = np.random.choice(np.arange(len(index)), size=2, replace=False)
-    return slice(*sorted(points))
+def slice_subset(index, min_size=2):
+    while True:
+        points = np.random.choice(np.arange(len(index) + 1), size=2, replace=False)
+        s = slice(*sorted(points))
+        if len(range(*s.indices(len(index)))) >= min_size:
+            break
+    return s
 
 def single_subset(index):
     return index[np.random.randint(0, len(index), size=())]

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -549,12 +549,12 @@ def test_1d_slice_dtypes():
     new_obs_df = pd.DataFrame(index=adata.obs_names)
     for k in obs_df.columns:
         new_obs_df[k] = adata.obs_vector(k)
-        assert new_obs_df[k].dtype is obs_df[k].dtype
+        assert new_obs_df[k].dtype == obs_df[k].dtype
     assert np.all(new_obs_df == obs_df)
     new_var_df = pd.DataFrame(index=adata.var_names)
     for k in var_df.columns:
         new_var_df[k] = adata.var_vector(k)
-        assert new_var_df[k].dtype is var_df[k].dtype
+        assert new_var_df[k].dtype == var_df[k].dtype
     assert np.all(new_var_df == var_df)
 
 

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -179,10 +179,10 @@ def test_slicing_strings():
     assert adata[:, 'b':'c'].X.tolist() == [[2, 3], [5, 6]]
 
     from pytest import raises
-    with raises(IndexError): _ = adata[:, 'X']
-    with raises(IndexError): _ = adata['X', :]
-    with raises(IndexError): _ = adata['A':'X', :]
-    with raises(IndexError): _ = adata[:, 'a':'X']
+    with raises(KeyError): _ = adata[:, 'X']
+    with raises(KeyError): _ = adata['X', :]
+    with raises(KeyError): _ = adata['A':'X', :]
+    with raises(KeyError): _ = adata[:, 'a':'X']
 
     # Test if errors are helpful
     with raises(KeyError, match=r"not_in_var"):

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -115,11 +115,11 @@ def test_slicing():
     adata = AnnData(np.array([[1, 2, 3],
                               [4, 5, 6]]))
 
-    assert adata[:, 0].X.tolist() == adata.X[:, 0].tolist()
+    # assert adata[:, 0].X.tolist() == adata.X[:, 0].tolist()  # No longer the case
 
-    assert adata[0, 0].X.tolist() == 1
-    assert adata[0, :].X.tolist() == [1, 2, 3]
-    assert adata[:, 0].X.tolist() == [1, 4]
+    assert adata[0, 0].X.tolist() == np.reshape(1, (1, 1)).tolist()
+    assert adata[0, :].X.tolist() == np.reshape([1, 2, 3], (1, 3)).tolist()
+    assert adata[:, 0].X.tolist() == np.reshape([1, 4], (2, 1)).tolist()
 
     assert adata[:, [0, 1]].X.tolist() == [[1, 2], [4, 5]]
     assert adata[:, np.array([0, 2])].X.tolist() == [[1, 3], [4, 6]]
@@ -127,11 +127,11 @@ def test_slicing():
     assert adata[:, 1:3].X.tolist() == [[2, 3], [5, 6]]
 
     assert adata[0:2, :][:, 0:2].X.tolist() == [[1,2], [4,5]]
-    assert adata[0:1, :][:, 0:2].X.tolist() == [1,2]
-    assert adata[0, :][:, 0].X.tolist() == 1
+    assert adata[0:1, :][:, 0:2].X.tolist() == np.reshape([1,2], (1, 2)).tolist()
+    assert adata[0, :][:, 0].X.tolist() == np.reshape(1, (1,1)).tolist()
     assert adata[:, 0:2][0:2, :].X.tolist() == [[1,2], [4,5]]
-    assert adata[:, 0:2][0:1, :].X.tolist() == [1,2]
-    assert adata[:, 0][0, :].X.tolist() == 1
+    assert adata[:, 0:2][0:1, :].X.tolist() == np.reshape([1,2], (1, 2)).tolist()
+    assert adata[:, 0][0, :].X.tolist() == np.reshape(1, (1,1)).tolist()
 
 
 def test_boolean_slicing():
@@ -140,21 +140,21 @@ def test_boolean_slicing():
 
     obs_selector = np.array([True, False], dtype=bool)
     vars_selector = np.array([True, False, False], dtype=bool)
-    assert adata[obs_selector, :][:, vars_selector].X.tolist() == 1
-    assert adata[:, vars_selector][obs_selector, :].X.tolist() == 1
-    assert adata[obs_selector, :][:, 0].X.tolist() == 1
-    assert adata[:, 0][obs_selector, :].X.tolist() == 1
-    assert adata[0, :][:, vars_selector].X.tolist() == 1
-    assert adata[:, vars_selector][0, :].X.tolist() == 1
+    assert adata[obs_selector, :][:, vars_selector].X.tolist() == [[1]]
+    assert adata[:, vars_selector][obs_selector, :].X.tolist() == [[1]]
+    assert adata[obs_selector, :][:, 0].X.tolist() == [[1]]
+    assert adata[:, 0][obs_selector, :].X.tolist() == [[1]]
+    assert adata[0, :][:, vars_selector].X.tolist() == [[1]]
+    assert adata[:, vars_selector][0, :].X.tolist() == [[1]]
 
     obs_selector = np.array([True, False], dtype=bool)
     vars_selector = np.array([True, True, False], dtype=bool)
-    assert adata[obs_selector, :][:, vars_selector].X.tolist() == [1, 2]
-    assert adata[:, vars_selector][obs_selector, :].X.tolist() == [1, 2]
-    assert adata[obs_selector, :][:, 0:2].X.tolist() == [1, 2]
-    assert adata[:, 0:2][obs_selector, :].X.tolist() == [1, 2]
-    assert adata[0, :][:, vars_selector].X.tolist() == [1, 2]
-    assert adata[:, vars_selector][0, :].X.tolist() == [1, 2]
+    assert adata[obs_selector, :][:, vars_selector].X.tolist() == [[1, 2]]
+    assert adata[:, vars_selector][obs_selector, :].X.tolist() == [[1, 2]]
+    assert adata[obs_selector, :][:, 0:2].X.tolist() == [[1, 2]]
+    assert adata[:, 0:2][obs_selector, :].X.tolist() == [[1, 2]]
+    assert adata[0, :][:, vars_selector].X.tolist() == [[1, 2]]
+    assert adata[:, vars_selector][0, :].X.tolist() == [[1, 2]]
 
     obs_selector = np.array([True, True], dtype=bool)
     vars_selector = np.array([True, True, False], dtype=bool)
@@ -186,9 +186,9 @@ def test_slicing_strings():
         dict(obs_names=['A', 'B']),
         dict(var_names=['a', 'b', 'c']))
 
-    assert adata['A', 'a'].X.tolist() == 1
-    assert adata['A', :].X.tolist() == [1, 2, 3]
-    assert adata[:, 'a'].X.tolist() == [1, 4]
+    assert adata['A', 'a'].X.tolist() == [[1]]
+    assert adata['A', :].X.tolist() == [[1, 2, 3]]
+    assert adata[:, 'a'].X.tolist() == [[1], [4]]
     assert adata[:, ['a', 'b']].X.tolist() == [[1, 2], [4, 5]]
     assert adata[:, np.array(['a', 'c'])].X.tolist() == [[1, 3], [4, 6]]
     assert adata[:, 'b':'c'].X.tolist() == [[2, 3], [5, 6]]

--- a/anndata/tests/test_deprecations.py
+++ b/anndata/tests/test_deprecations.py
@@ -33,7 +33,7 @@ def test_get_obsvar_array_warn(adata):
         adata._get_var_array("s1")
 
 
-# TODO: Why doesn't mark this work?
+# TODO: Why doesn't this mark work?
 @pytest.mark.filterwarnings("ignore::DeprecationWarning:anndata[.*]")
 def test_get_obsvar_array(adata):
     assert np.allclose(

--- a/anndata/tests/test_deprecations.py
+++ b/anndata/tests/test_deprecations.py
@@ -33,6 +33,8 @@ def test_get_obsvar_array_warn(adata):
         adata._get_var_array("s1")
 
 
+# TODO: Why doesn't mark this work?
+@pytest.mark.filterwarnings("ignore::DeprecationWarning:anndata[.*]")
 def test_get_obsvar_array(adata):
     assert np.allclose(
         adata._get_obs_array("a"),

--- a/anndata/tests/test_hdf5_backing.py
+++ b/anndata/tests/test_hdf5_backing.py
@@ -64,13 +64,13 @@ def test_backing(adata, tmp_path, backing_h5ad):
     assert not adata.file.isopen
     assert adata.isbacked
     assert adata[:, 0].isview
-    assert adata[:, 0].X.tolist() == [1, 4, 7]
+    assert adata[:, 0].X.tolist() == np.reshape([1, 4, 7], (3, 1)).tolist()
     # this might give us a trouble as the user might not
     # know that the file is open again....
     assert adata.file.isopen
 
     adata[:2, 0].X = [0, 0]
-    assert adata[:, 0].X.tolist() == [0, 0, 7]
+    assert adata[:, 0].X.tolist() == np.reshape([0, 0, 7], (3, 1)).tolist()
 
     adata_subset = adata[:2, [0, 1]]
     assert adata_subset.isview

--- a/anndata/tests/test_hdf5_backing.py
+++ b/anndata/tests/test_hdf5_backing.py
@@ -172,3 +172,26 @@ def test_backed_modification_sparse(adata, backing_h5ad, sparse_format):
     assert np.all(adata.X[0, :] == np.array([10, 0, 10]))
     assert np.all(adata.X[1, :] == np.array([11, 0, 12]))
     assert np.all(adata.X[2, :] == np.array([7, 0, 9]))
+
+
+# TODO: Work around h5py not supporting this
+# def test_backed_view_modification(adata, backing_h5ad):
+#     adata.write(backing_h5ad)
+#     backed_adata = ad.read_h5ad(backing_h5ad, backed=True)
+
+#     backed_view = backed_adata[[1, 2], :]
+#     backed_view.X = 0
+
+#     assert np.all(backed_adata.X[:3, :] == 0)
+
+
+# TODO: Implement
+# def test_backed_view_modification_sparse(adata, backing_h5ad, sparse_format):
+#     adata[:, 1] = 0  # Make it a little sparse
+#     adata.X = sparse_format(adata.X)
+#     adata.write(backing_h5ad)
+#     backed_adata = ad.read_h5ad(backing_h5ad, backed=True)
+
+#     backed_view = backed_adata[[1,2], :]
+#     backed_view.X = 0
+#     assert np.all(backed_adata.X[[1,2], :] == 0)

--- a/anndata/tests/test_inplace_subset.py
+++ b/anndata/tests/test_inplace_subset.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+from sklearn.utils.testing import (
+    assert_array_equal
+)
+from scipy import sparse
+
+from anndata.tests.helpers import (
+    gen_adata,
+    subset_func,
+    asarray
+)
+
+@pytest.fixture(
+    params=[np.array, sparse.csr_matrix, sparse.csc_matrix],
+    ids=["np_array", "scipy_csr", "scipy_csc"]
+)
+def matrix_type(request):
+    return request.param
+
+# TODO: Test values of .uns
+def test_inplace_subset_var(matrix_type, subset_func):
+    orig = gen_adata((30, 30), X_type=matrix_type)
+    subset_idx = subset_func(orig.var_names)
+
+    modified = orig.copy()
+    from_view = orig[:, subset_idx].copy()
+    modified._inplace_subset_var(subset_idx)
+
+    assert_array_equal(asarray(from_view.X), asarray(modified.X))
+    assert_array_equal(from_view.obs, modified.obs)
+    assert_array_equal(from_view.var, modified.var)
+    for k in from_view.obsm:
+        assert_array_equal(asarray(from_view.obsm[k]), asarray(modified.obsm[k]))
+        assert_array_equal(asarray(orig.obsm[k]), asarray(modified.obsm[k]))
+    for k in from_view.varm:
+        assert_array_equal(asarray(from_view.varm[k]), asarray(modified.varm[k]))
+    for k in from_view.layers:
+        assert_array_equal(asarray(from_view.layers[k]), asarray(modified.layers[k]))
+
+def test_inplace_subset_obs(matrix_type, subset_func):
+    orig = gen_adata((30, 30), X_type=matrix_type)
+    subset_idx = subset_func(orig.obs_names)
+
+    modified = orig.copy()
+    from_view = orig[subset_idx, :].copy()
+    modified._inplace_subset_obs(subset_idx)
+
+    assert_array_equal(asarray(from_view.X), asarray(modified.X))
+    assert_array_equal(from_view.obs, modified.obs)
+    assert_array_equal(from_view.var, modified.var)
+    for k in from_view.obsm:
+        assert_array_equal(asarray(from_view.obsm[k]), asarray(modified.obsm[k]))
+    for k in from_view.varm:
+        assert_array_equal(asarray(from_view.varm[k]), asarray(modified.varm[k]))
+        assert_array_equal(asarray(orig.varm[k]), asarray(modified.varm[k]))
+    for k in from_view.layers:
+        assert_array_equal(asarray(from_view.layers[k]), asarray(modified.layers[k]))

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -5,7 +5,12 @@ import pytest
 
 import anndata as ad
 
-from anndata.tests.helpers import gen_adata, subset_func, slice_subset
+from anndata.tests.helpers import (
+    gen_adata,
+    subset_func,
+    slice_subset,
+    single_subset
+)
 
 # -------------------------------------------------------------------------------
 # Some test data
@@ -290,6 +295,8 @@ def test_layers_view():
 
 
 def test_view_of_view(adata, subset_func):
-    v1 = adata[:, subset_func(adata.var_names)]
-    v2 = subset[:, subset_func(subset.var_names)]
+    s1 = subset_func(adata.var_names)
+    v1 = adata[:, s1]
+    s2 = subset_func(v1.var_names)
+    v2 = v1[:, s2]
     assert v2._adata_ref is adata

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -331,6 +331,14 @@ def test_view_of_view(matrix_type, subset_func, subset_func2):
         asarray(view_of_actual_copy.X),
         asarray(view_of_view_copy.X)
     )
+    assert np.all(asarray(eq(
+        view_of_actual_copy.obs,
+        view_of_view_copy.obs
+    )))
+    assert np.all(asarray(eq(
+        view_of_actual_copy.var,
+        view_of_view_copy.var
+    )))
     for k in adata.obsm.keys():
         assert np.all(asarray(eq(
             view_of_actual_copy.obsm[k],
@@ -338,8 +346,8 @@ def test_view_of_view(matrix_type, subset_func, subset_func2):
         )))
     for k in adata.varm.keys():
         assert np.all(asarray(eq(
-            asarray(view_of_actual_copy.layers[k]),
-            asarray(view_of_view_copy.layers[k])
+            asarray(view_of_actual_copy.varm[k]),
+            asarray(view_of_view_copy.varm[k])
         )))
     for k in adata.layers.keys():
         assert np.all(asarray(eq(

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -391,3 +391,15 @@ def test_view_of_view_modification():
     assert np.all(asarray(adata.X)[0, 5:] == np.ones(5) * 2)
     adata[[1, 2], :][:, [1, 2]].X = np.ones((2, 2)) * 2
     assert np.all(asarray(adata.X)[1:3, 1:3] == np.ones((2, 2)) * 2)
+
+
+def test_double_index(subset_func, subset_func2):
+    adata = gen_adata((10, 10))
+    obs_subset = subset_func(adata.obs_names)
+    var_subset = subset_func2(adata.var_names)
+    v1 = adata[obs_subset, var_subset]
+    v2 = adata[obs_subset, :][:, var_subset]
+
+    assert np.all(asarray(v1.X) == asarray(v2.X))
+    assert np.all(v1.obs == v2.obs)
+    assert np.all(v1.var == v2.var)

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -287,3 +287,9 @@ def test_layers_view():
     assert not view_adata.isview
     assert real_hash == joblib.hash(real_adata)
     assert view_hash != joblib.hash(view_adata)
+
+
+def test_view_of_view(adata, subset_func):
+    v1 = adata[:, subset_func(adata.var_names)]
+    v2 = subset[:, subset_func(subset.var_names)]
+    assert v2._adata_ref is adata

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -346,3 +346,16 @@ def test_view_of_view(matrix_type, subset_func, subset_func2):
             asarray(view_of_actual_copy.layers[k]),
             asarray(view_of_view_copy.layers[k])
         )))
+
+def test_view_of_view_modification():
+    adata = ad.AnnData(np.zeros((10, 10)))
+    adata[0, :][:, 5:].X = np.ones(5)
+    assert np.all(adata.X[0, 5:] == np.ones(5))
+    adata[[1,2], :][:, [1,2]].X = np.ones((2, 2))
+    assert np.all(adata.X[1:3, 1:3] == np.ones((2, 2)))
+
+    adata.X = sparse.csr_matrix(adata.X)
+    adata[0, :][:, 5:].X = np.ones(5) * 2
+    assert np.all(asarray(adata.X)[0, 5:] == np.ones(5) * 2)
+    adata[[1, 2], :][:, [1, 2]].X = np.ones((2, 2)) * 2
+    assert np.all(asarray(adata.X)[1:3, 1:3] == np.ones((2, 2)) * 2)

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -1,4 +1,4 @@
-from operator import eq
+from operator import eq, ne
 
 import joblib
 import numpy as np
@@ -49,7 +49,10 @@ def adata_parameterized(request):
     return gen_adata(shape=(200, 300), X_type=request.param)
 
 
-@pytest.fixture(params=[np.array, sparse.csr_matrix, sparse.csc_matrix])
+@pytest.fixture(
+    params=[np.array, sparse.csr_matrix, sparse.csc_matrix],
+    ids=["np_array", "scipy_csr", "scipy_csc"]
+)
 def matrix_type(request):
     return request.param
 
@@ -354,26 +357,26 @@ def test_view_of_view(matrix_type, subset_func, subset_func2):
         asarray(view_of_actual_copy.X),
         asarray(view_of_view_copy.X)
     )
-    assert np.all(asarray(eq(
+    assert not np.any(asarray(ne(
         view_of_actual_copy.obs,
         view_of_view_copy.obs
     )))
-    assert np.all(asarray(eq(
+    assert not np.any(asarray(ne(
         view_of_actual_copy.var,
         view_of_view_copy.var
     )))
     for k in adata.obsm.keys():
-        assert np.all(asarray(eq(
+        assert not np.any(asarray(ne(
             view_of_actual_copy.obsm[k],
             view_of_view_copy.obsm[k]
         )))
     for k in adata.varm.keys():
-        assert np.all(asarray(eq(
+        assert not np.any(asarray(ne(
             asarray(view_of_actual_copy.varm[k]),
             asarray(view_of_view_copy.varm[k])
         )))
     for k in adata.layers.keys():
-        assert np.all(asarray(eq(
+        assert not np.any(asarray(ne(
             asarray(view_of_actual_copy.layers[k]),
             asarray(view_of_view_copy.layers[k])
         )))

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -84,7 +84,6 @@ def test_views():
 
 
 def test_modify_view_component(matrix_type, mapping_name):
-    def getter(x): return getattr(x, mapping_name)
     adata = ad.AnnData(
         np.zeros((10, 10)),
         **{mapping_name:

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -67,11 +67,11 @@ def test_views():
     adata = ad.AnnData(X, obs=obs_dict, var=var_dict, uns=uns_dict, dtype='int32')
 
     assert adata[:, 0].isview
-    assert adata[:, 0].X.tolist() == [1, 4, 7]
+    assert adata[:, 0].X.tolist() == np.reshape([1, 4, 7], (3, 1)).tolist()
 
     adata[:2, 0].X = [0, 0]
 
-    assert adata[:, 0].X.tolist() == [0, 0, 7]
+    assert adata[:, 0].X.tolist() == np.reshape([0, 0, 7], (3, 1)).tolist()
 
     adata_subset = adata[:2, [0, 1]]
 

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -219,6 +219,26 @@ def test_set_varm(adata):
 
     assert init_hash == joblib.hash(adata)
 
+# TODO: Determine if this is the intended behavior, or just the behaviour we've had for a while
+def test_set_subset_X(matrix_type, subset_func):
+    adata = ad.AnnData(matrix_type(asarray(sparse.random(20, 20))))
+    init_hash = joblib.hash(adata)
+    orig_X_val = adata.X.copy()
+    while True:
+        subset_idx = slice_subset(adata.obs_names)
+        if len(adata[subset_idx, :]) > 2:
+            break
+    subset = adata[subset_idx, :]
+
+    subset = adata[:, subset_idx]
+
+    internal_idx = subset_func(np.arange(subset.X.shape[1]))
+    assert subset.isview
+    subset.X[:, internal_idx] = 1
+    assert not subset.isview
+    assert not np.any(asarray(adata.X != orig_X_val))
+
+    assert init_hash == joblib.hash(adata)
 
 # TODO: Use different kind of subsetting for adata and view
 def test_set_subset_obsm(adata, subset_func):

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -1,4 +1,4 @@
-from operator import eq, ne
+from operator import eq, ne, mul
 
 import joblib
 import numpy as np
@@ -220,7 +220,7 @@ def test_set_varm(adata):
     assert init_hash == joblib.hash(adata)
 
 # TODO: Determine if this is the intended behavior, or just the behaviour we've had for a while
-def test_set_subset_X(matrix_type, subset_func):
+def test_not_set_subset_X(matrix_type, subset_func):
     adata = ad.AnnData(matrix_type(asarray(sparse.random(20, 20))))
     init_hash = joblib.hash(adata)
     orig_X_val = adata.X.copy()
@@ -239,6 +239,20 @@ def test_set_subset_X(matrix_type, subset_func):
     assert not np.any(asarray(adata.X != orig_X_val))
 
     assert init_hash == joblib.hash(adata)
+
+def test_set_scalar_subset_X(matrix_type, subset_func):
+    adata = ad.AnnData(matrix_type(np.zeros((10, 10))))
+    orig_X_val = adata.X.copy()
+    subset_idx = slice_subset(adata.obs_names)
+
+    adata_subset = adata[subset_idx, :]
+
+    adata_subset.X = 1
+
+    assert adata_subset.isview
+    assert np.all(asarray(adata[subset_idx, :].X) == 1)
+
+    assert asarray((orig_X_val != adata.X)).sum() == mul(*adata_subset.shape)
 
 # TODO: Use different kind of subsetting for adata and view
 def test_set_subset_obsm(adata, subset_func):

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,6 +3,29 @@
 .. role:: noteversion
 
 
+On Master :small:`July 29, 2019`
+--------------------------------
+
+.. warning::
+
+    Breaking changes on master include: 
+
+    - Elements of `AnnData` objects don't have their dimensionality reduced when the main object is subset. This is to maintain consistency when subsetting. See discussion `here <https://github.com/theislab/anndata/issues/145>`__.
+    - While the `anndata.core` module currently exists, it may be renamed to `anndata._core` `#174 <https://github.com/theislab/anndata/issues/174>`__.
+
+    Currently broken features
+
+    - `sc.pp.normalize_per_cell` doesn't work on dask arrays. It just doesn't modify the matrix.
+
+
+- Views have been overhauled  `PR #164 <https://github.com/theislab/anndata/pull/164>`__.
+
+   - Indexing into a view no longer keeps a reference to intermediate view, `issue #62 <https://github.com/theislab/anndata/issues/62>`__.
+   - Views are now lazy. Elements of view of AnnData are not indexed until they're accessed.
+   - Indexing with scalars no longer reduces dimensionality of contained arrays, `issue #145 <https://github.com/theislab/anndata/issues/145>`__.
+   - All elements of AnnData should now follow the same rules about how they're subset, `issue #145 <https://github.com/theislab/anndata/issues/145>`__.
+   - Can now index by observations and variables at the same time.
+
 Post v0.6 :small:`June 6, 2019`
 ---------------------------------
 
@@ -40,7 +63,7 @@ Version 0.5 :small:`February 9, 2018`
 
 
 Version 0.4 :small:`December 23, 2017`
--------------------------------------
+--------------------------------------
 
 - read/write `.loom <http://loompy.org>`__ files
 - scalability beyond dataset sizes that fit into memory: see this `blog post <http://falexwolf.de/blog/171223_AnnData_indexing_views_HDF5-backing/>`__


### PR DESCRIPTION
Addressing #62.

This PR aims to make it so when you subset an AnnDataView, it makes a reference to the original AnnData.

Things left to do:

- [x] The test is a bit flaky, for certain combinations of subsetting techniques it generates incompatible indexers.
- [x] I should make sure AlignedMappings work well with this, I suspect they may not due to problems getting `.X` working right.

-----------------------------

Update:

A few more features of this pull request:

* Memory usage from taking a view are significantly reduced, since X is now lazy for views (You only subset X if the user accesses the attribute)
* More extensive testing of subsetting anndata objects