### PR TITLE
fixed index bug in _remove_unused_categories

### DIFF
--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -1235,12 +1235,13 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 df_sub[k].cat.remove_unused_categories(inplace=True)
                 # also correct the colors...
                 if k + '_colors' in uns:
-                    # this is a strange hack...
+                    # this is a strange hack...cd wor   
                     if np.array(uns[k + '_colors']).ndim == 0:
                         uns[k + '_colors'] = np.array(uns[k + '_colors'])[None]
-                    uns[k + '_colors'] = np.array(uns[k + '_colors'])[
-                        np.where(np.in1d(
-                            all_categories, df_sub[k].cat.categories))[0]]
+                    elif np.array(uns[k + '_colors']).ndim > 1:
+                        uns[k + '_colors'] = np.array(uns[k + '_colors'])[
+                            np.where(np.in1d(
+                                all_categories, df_sub[k].cat.categories))[0]]
 
     def rename_categories(self, key: str, categories: Sequence[Any]):
         """Rename categories of annotation ``key`` in

--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -1252,18 +1252,21 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
     def _remove_unused_categories(self, df_full, df_sub, uns):
         from pandas.api.types import is_categorical
         for k in df_full:
-            if is_categorical(df_full[k]):
-                all_categories = df_full[k].cat.categories
-                df_sub[k].cat.remove_unused_categories(inplace=True)
-                # also correct the colors...
-                if k + '_colors' in uns:
-                    # this is a strange hack...
-                    if np.array(uns[k + '_colors']).ndim == 0:
-                        uns[k + '_colors'] = np.array(uns[k + '_colors'])[None]
-                    elif np.array(uns[k + '_colors']).ndim > 1:
-                        uns[k + '_colors'] = np.array(uns[k + '_colors'])[
-                            np.where(np.in1d(
-                                all_categories, df_sub[k].cat.categories))[0]]
+            if not is_categorical(df_full[k]):
+                continue
+            all_categories = df_full[k].cat.categories
+            df_sub[k].cat.remove_unused_categories(inplace=True)
+            # also correct the colors...
+            if f'{k}_colors' not in uns:
+                continue
+            # this is a strange hack...
+            if np.array(uns[f'{k}_colors']).ndim == 0:
+                idx = [None]
+            else:
+                idx = [np.where(np.in1d(
+                    all_categories, df_sub[k].cat.categories
+                ))[0]]
+            uns[f'{k}_colors'] = np.array(uns[f'{k}_colors'])[idx]
 
     def rename_categories(self, key: str, categories: Sequence[Any]):
         """Rename categories of annotation ``key`` in

--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -1235,7 +1235,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 df_sub[k].cat.remove_unused_categories(inplace=True)
                 # also correct the colors...
                 if k + '_colors' in uns:
-                    # this is a strange hack...cd wor   
+                    # this is a strange hack...
                     if np.array(uns[k + '_colors']).ndim == 0:
                         uns[k + '_colors'] = np.array(uns[k + '_colors'])[None]
                     elif np.array(uns[k + '_colors']).ndim > 1:


### PR DESCRIPTION
I had an issue with subsetting AnnData objects created in scVelo where `AnnData._remove_unused_categories()` was attempting to, I suppose, incorrectly subset some `.uns` color values.  

In particular, I had a `.obs` key named `cluster`, representing the cluster number from `scanpy.tl.leiden` and a corresponding value in `.uns['cluster_color']`.  When subsetting the object for any cell that was in a cluster between 2 and 9, `_remove_unused_categories()` tried to use that cluster number to subset the one member `.uns['cluster_color']` Series, giving rise to an `index 12 is out of bounds for axis 0 with size 11` error.

I've added a check to `_remove_unused_categories()` so that it now first checks to see if any subsetting is of a `_color` uns member is necessary to prevent such an error.