### PR TITLE
Allow asking for a key of obs when use_raw=True in deprecated _get_{obs,var}_array

### DIFF
--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -1529,19 +1529,19 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
     def _get_obs_array(self, k, use_raw=False, layer=None):
         """Get an array from the layer (default layer='X') along the observation dimension by first looking up
         obs.keys and then var.index."""
-        if use_raw:
-            return self.raw.obs_vector(k)
-        else:
+        if not use_raw or k in self.obs.columns:
             return self.obs_vector(k=k, layer=layer)
+        else:
+            return self.raw.obs_vector(k)
 
     @utils.deprecated("var_vector")
     def _get_var_array(self, k, use_raw=False, layer=None):
         """Get an array from the layer (default layer='X') along the variables dimension by first looking up
         ``var.keys`` and then ``obs.index``."""
-        if use_raw:
-            return self.raw.var_vector(k)
-        else:
+        if not use_raw or k in self.var.columns:
             return self.var_vector(k=k, layer=layer)
+        else:
+            return self.raw.var_vector(k)
 
     def copy(self, filename: Optional[PathLike] = None) -> 'AnnData':
         """Full copy, optionally on disk."""


### PR DESCRIPTION
Part of https://github.com/theislab/scanpy/issues/728 and releasing v0.6.22

This throws an error on master:

```python
import scanpy as sc
pbmc = sc.datasets.pbmc68k_reduced()
sc.pl.scatter(pbmc, "n_genes", "HES1")
```

It doesn't after this commit.

All this does is fix a backward breaking change. `sc.pl.scatter` still needs to be fixed so it doesn't use the deprecated function, but this is a little more challenging.