### PR TITLE
ipython tab completion for layers, obsm, varm

### DIFF
--- a/anndata/core/alignedmapping.py
+++ b/anndata/core/alignedmapping.py
@@ -38,6 +38,9 @@ class AlignedMapping(MutableMapping, ABC):
             self.__class__.__name__, ', '.join(self.keys())
         )
 
+    def _ipython_key_completions_(self):
+        return list(self.keys())
+
     def _validate_value(self, val, key) -> None:
         """Raises an error if value is invalid"""
         for i, axis in enumerate(self.axes):


### PR DESCRIPTION
I was procrastinating and found an easy win.

`layers`, `obsm`, `varm` and soon `obsp`, `varp` will now all support tab completion for their keys through ipython.