### PR TITLE
Update docs/require.txt to work with setuptools_scm

### DIFF
--- a/docs/requires.txt
+++ b/docs/requires.txt
@@ -1,4 +1,6 @@
 # stuff necessary for docs generation
+setuptools_scm
+importlib_metadata>=0.7; python_version < '3.8'
 sphinx>=1.8
 sphinx-autodoc-typehints
 scanpydoc>=0.3.2


### PR DESCRIPTION
@flying-sheep, readthedocs was complaining about not having setuptools_scm or importlib_metadata installed. `setuptools_scm` recommends against this approach, but I'm not sure how to do this without also having to load `authors` another way.

I'm also going to go apply this to `scanpy`.