### PR TITLE
Add obsp and varp

### DIFF
--- a/anndata/core/alignedmapping.py
+++ b/anndata/core/alignedmapping.py
@@ -292,30 +292,28 @@ class PairwiseArraysBase(AlignedMapping):
         return self._dimnames[self._axis]
 
 
-
-# TODO: Allow these to be written, and add them back to anndata
-# class PairwiseArrays(AlignedActualMixin, PairwiseArraysBase):
-#     def __init__(self, parent: "AnnData", axis: int, vals: Optional[Mapping] = None):
-#         self._parent = parent
-#         if axis not in (0, 1):
-#             raise ValueError()
-#         self._axis = axis
-#         self.dim_names = (parent.obs_names, parent.var_names)[self._axis]
-#         self._data = dict()
-#         if vals is not None:
-#             self.update(vals)
+class PairwiseArrays(AlignedActualMixin, PairwiseArraysBase):
+    def __init__(self, parent: "AnnData", axis: int, vals: Optional[Mapping] = None):
+        self._parent = parent
+        if axis not in (0, 1):
+            raise ValueError()
+        self._axis = axis
+        self.dim_names = (parent.obs_names, parent.var_names)[self._axis]
+        self._data = dict()
+        if vals is not None:
+            self.update(vals)
 
 
-# class PairwiseArraysView(AlignedViewMixin, PairwiseArraysBase):
-#     def __init__(
-#         self, parent_mapping: PairwiseArraysBase, parent_view: "AnnData", subset_idx
-#     ):
-#         self.parent_mapping = parent_mapping
-#         self._parent = parent_view
-#         self.subset_idx = (subset_idx, subset_idx)
-#         self._axis = parent_mapping._axis
-#         self.dim_names = parent_mapping.dim_names[subset_idx]
+class PairwiseArraysView(AlignedViewMixin, PairwiseArraysBase):
+    def __init__(
+        self, parent_mapping: PairwiseArraysBase, parent_view: "AnnData", subset_idx
+    ):
+        self.parent_mapping = parent_mapping
+        self._parent = parent_view
+        self.subset_idx = (subset_idx, subset_idx)
+        self._axis = parent_mapping._axis
+        self.dim_names = parent_mapping.dim_names[subset_idx]
 
 
-# PairwiseArraysBase._view_class = PairwiseArraysView
-# PairwiseArraysBase._actual_class = PairwiseArrays
+PairwiseArraysBase._view_class = PairwiseArraysView
+PairwiseArraysBase._actual_class = PairwiseArrays

--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -581,7 +581,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         obsp: Optional[Union[np.ndarray, Mapping[str, Sequence[Any]]]] = None,
         varp: Optional[Union[np.ndarray, Mapping[str, Sequence[Any]]]] = None,
         oidx: Index1D = None,
-        vidx: Index1D = None
+        vidx: Index1D = None,
     ):
         if asview:
             if not isinstance(X, AnnData):
@@ -595,7 +595,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 layers=layers,
                 dtype=dtype, shape=shape,
                 obsp=obsp, varp=varp,
-                filename=filename, filemode=filemode
+                filename=filename, filemode=filemode,
             )
 
     def _init_as_view(self, adata_ref: 'AnnData', oidx: Index, vidx: Index):
@@ -612,7 +612,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             oidx, vidx = _resolve_idxs(
                 (prev_oidx, prev_vidx),
                 (oidx, vidx),
-                adata_ref
+                adata_ref,
             )
         self._adata_ref = adata_ref
         self._oidx = oidx
@@ -660,7 +660,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         varp=None, obsp=None,
         raw=None, layers=None,
         dtype='float32', shape=None,
-        filename=None, filemode=None
+        filename=None, filemode=None,
     ):
         # view attributes
         self._isview = False
@@ -1591,7 +1591,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 varp=self.varp.copy(),
                 raw=None if self._raw is None else self._raw.copy(),
                 layers=self.layers.copy(),
-                dtype=dtype
+                dtype=dtype,
             )
         else:
             from ..readwrite import read_h5ad
@@ -1609,7 +1609,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         join: str = 'inner',
         batch_key: str = 'batch',
         batch_categories: Sequence[Any] = None,
-        index_unique: Optional[str] = '-'
+        index_unique: Optional[str] = '-',
     ) -> 'AnnData':
         """Concatenate along the observations axis.
 
@@ -2023,7 +2023,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         filename: Optional[PathLike] = None,
         compression: Optional[str] = None,
         compression_opts: Union[int, Any] = None,
-        force_dense: Optional[bool] = None
+        force_dense: Optional[bool] = None,
     ):
         """Write ``.h5ad``-formatted hdf5 file.
 

--- a/anndata/readwrite/h5ad.py
+++ b/anndata/readwrite/h5ad.py
@@ -89,6 +89,8 @@ def write_h5ad(
         write_attribute(f, "var", adata.var, dataset_kwargs)
         write_attribute(f, "obsm", adata.obsm, dataset_kwargs)
         write_attribute(f, "varm", adata.varm, dataset_kwargs)
+        write_attribute(f, "obsp", adata.obsp, dataset_kwargs)
+        write_attribute(f, "varp", adata.varp, dataset_kwargs)
         write_attribute(f, "layers", adata.layers, dataset_kwargs)
         write_attribute(f, "uns", adata.uns, dataset_kwargs)
         write_attribute(f, "raw", adata.raw, dataset_kwargs)
@@ -218,7 +220,7 @@ def read_h5ad_backed(filename: Union[str, Path], mode: str) -> AnnData:
 
     f = adh5py.File(filename, mode)
 
-    attributes = ["obsm", "varm", "uns", "layers"]
+    attributes = ["obsm", "varm", "obsp", "varp", "uns", "layers"]
     df_attributes = ["obs", "var"]
 
     d.update({k: read_attribute(f[k]) for k in attributes if k in f})

--- a/anndata/readwrite/zarr.py
+++ b/anndata/readwrite/zarr.py
@@ -39,6 +39,8 @@ def write_zarr(
     write_attribute(f, "var", adata.var, dataset_kwargs)
     write_attribute(f, "obsm", adata.obsm, dataset_kwargs)
     write_attribute(f, "varm", adata.varm, dataset_kwargs)
+    write_attribute(f, "obsp", adata.obsp, dataset_kwargs)
+    write_attribute(f, "varp", adata.varp, dataset_kwargs)
     write_attribute(f, "layers", adata.layers, dataset_kwargs)
     write_attribute(f, "uns", adata.uns, dataset_kwargs)
     write_attribute(f, "raw", adata.raw, dataset_kwargs)

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -119,6 +119,14 @@ def gen_adata(
         "df": gen_typed_df_t2_size(M, N, index=obs_names, columns=var_names)
     }
     layers = {k: v for k, v in layers.items() if type(v) in layers_types}
+    obsp = {
+        "array": np.random.random((M, M)),
+        "sparse": sparse.random(M, M, format="csr"),
+    }
+    varp = {
+        "array": np.random.random((N, N)),
+        "sparse": sparse.random(N, N, format="csr"),
+    }
     adata = AnnData(
         X=X_type(np.random.binomial(100, .005, (M, N)).astype(X_dtype)),
         obs=obs,
@@ -126,6 +134,8 @@ def gen_adata(
         obsm=obsm,
         varm=varm,
         layers=layers,
+        obsp=obsp,
+        varp=varp,
         dtype=X_dtype
     )
     return adata
@@ -325,7 +335,7 @@ def assert_adata_equal(a: AnnData, b: AnnData, exact: bool = False):
     assert_equal(a.obs, b.obs, exact, elem_name="obs")
     assert_equal(a.var, b.var, exact, elem_name="var")
     assert_equal(a.X, b.X, exact, elem_name="X")
-    for mapping_attr in ["obsm", "varm", "layers", "uns"]:
+    for mapping_attr in ["obsm", "varm", "layers", "uns", "obsp", "varp"]:
         assert_equal(
             getattr(a, mapping_attr),
             getattr(b, mapping_attr),
@@ -333,6 +343,6 @@ def assert_adata_equal(a: AnnData, b: AnnData, exact: bool = False):
             elem_name=mapping_attr
         )
     if a.raw is not None:
-        assert_equal(a.raw.X, b.raw.X, exact, elem_name="raw.X")
-        assert_equal(a.raw.var, b.raw.var, exact, elem_name="raw.var")
-        assert_equal(a.raw.varm, b.raw.varm, exact, elem_name="raw.varm")
+        assert_equal(a.raw.X, b.raw.X, exact, elem_name="raw/X")
+        assert_equal(a.raw.var, b.raw.var, exact, elem_name="raw/var")
+        assert_equal(a.raw.varm, b.raw.varm, exact, elem_name="raw/varm")

--- a/anndata/tests/test_obsmvarm.py
+++ b/anndata/tests/test_obsmvarm.py
@@ -6,18 +6,18 @@ from scipy import sparse
 
 import anndata
 
-N, M = (100, 100)
+M, N = (100, 100)
 
 
 @pytest.fixture
 def adata():
-    X = np.zeros((N, M))
+    X = np.zeros((M, N))
     obs = pd.DataFrame(
-        {"batch": np.array(["a", "b"])[np.random.randint(0, 2, N)]},
+        {"batch": np.array(["a", "b"])[np.random.randint(0, 2, M)]},
         index=["cell{:03d}".format(i) for i in range(N)]
     )
     var = pd.DataFrame(
-        index=["gene{:03d}".format(i) for i in range(M)]
+        index=["gene{:03d}".format(i) for i in range(N)]
     )
     return anndata.AnnData(X, obs=obs, var=var)
 
@@ -25,17 +25,17 @@ def adata():
 def test_assigmnent_dict(adata):
     d_obsm = {
         "a": pd.DataFrame(
-            {"a1": np.ones(N), "a2": ["a{}".format(i) for i in range(N)]},
+            {"a1": np.ones(M), "a2": ["a{}".format(i) for i in range(M)]},
             index=adata.obs_names
         ),
-        "b": np.zeros((N, 2))
+        "b": np.zeros((M, 2))
     }
     d_varm = {
         "a": pd.DataFrame(
-            {"a1": np.ones(M), "a2": ["a{}".format(i) for i in range(M)]},
+            {"a1": np.ones(N), "a2": ["a{}".format(i) for i in range(N)]},
             index=adata.var_names
         ),
-        "b": np.zeros((M, 2))
+        "b": np.zeros((N, 2))
     }
     adata.obsm = d_obsm
     for k, v in d_obsm.items():
@@ -46,30 +46,30 @@ def test_assigmnent_dict(adata):
 
 
 def test_setting_ndarray(adata):
-    adata.obsm["a"] = np.ones((N, 10))
-    adata.varm["a"] = np.ones((M, 10))
-    assert np.all(adata.obsm["a"] == np.ones((N, 10)))
-    assert np.all(adata.varm["a"] == np.ones((M, 10)))
+    adata.obsm["a"] = np.ones((M, 10))
+    adata.varm["a"] = np.ones((N, 10))
+    assert np.all(adata.obsm["a"] == np.ones((M, 10)))
+    assert np.all(adata.varm["a"] == np.ones((N, 10)))
 
     h = joblib.hash(adata)
     with pytest.raises(ValueError):
-        adata.obsm["b"] = np.ones((int(N / 2), 10))
+        adata.obsm["b"] = np.ones((int(M / 2), 10))
     with pytest.raises(ValueError):
-        adata.obsm["b"] = np.ones((int(N * 2), 10))
+        adata.obsm["b"] = np.ones((int(M * 2), 10))
     with pytest.raises(ValueError):
-        adata.varm["b"] = np.ones((int(M / 2), 10))
+        adata.varm["b"] = np.ones((int(N / 2), 10))
     with pytest.raises(ValueError):
-        adata.varm["b"] = np.ones((int(M * 2), 10))
+        adata.varm["b"] = np.ones((int(N * 2), 10))
     assert h == joblib.hash(adata)
 
 
 def test_setting_dataframe(adata):
     obsm_df = pd.DataFrame(
-        {"b_1": np.ones(N), "b_2": ["a" for i in range(N)]},
+        {"b_1": np.ones(M), "b_2": ["a" for i in range(M)]},
         index=adata.obs_names
     )
     varm_df = pd.DataFrame(
-        {"b_1": np.ones(M), "b_2": ["a" for i in range(M)]},
+        {"b_1": np.ones(N), "b_2": ["a" for i in range(N)]},
         index=adata.var_names
     )
 
@@ -90,21 +90,21 @@ def test_setting_dataframe(adata):
 
 
 def test_setting_sparse(adata):
-    obsm_sparse = sparse.random(N, 100)
+    obsm_sparse = sparse.random(M, 100)
     adata.obsm["a"] = obsm_sparse
     assert np.all((adata.obsm["a"] == obsm_sparse).data)
 
-    varm_sparse = sparse.random(M, 100)
+    varm_sparse = sparse.random(N, 100)
     adata.varm["a"] = varm_sparse
     assert np.all((adata.varm["a"] == varm_sparse).data)
 
     h = joblib.hash(adata)
 
-    bad_obsm_sparse = sparse.random(N * 2, N)
+    bad_obsm_sparse = sparse.random(M * 2, M)
     with pytest.raises(ValueError):
         adata.obsm["b"] = bad_obsm_sparse
 
-    bad_varm_sparse = sparse.random(M * 2, M)
+    bad_varm_sparse = sparse.random(N * 2, N)
     with pytest.raises(ValueError):
         adata.varm["b"] = bad_varm_sparse
 

--- a/anndata/tests/test_obspvarp.py
+++ b/anndata/tests/test_obspvarp.py
@@ -1,0 +1,91 @@
+# TODO: These tests should share code with test_layers, and test_obsmvarm
+import joblib
+import numpy as np
+import pandas as pd
+import pytest
+from scipy import sparse
+
+import anndata
+from anndata.tests.helpers import asarray
+
+M, N = (100, 100)
+
+
+@pytest.fixture
+def adata():
+    X = np.zeros((M, N))
+    obs = pd.DataFrame(
+        {"batch": np.array(["a", "b"])[np.random.randint(0, 2, M)]},
+        index=["cell{:03d}".format(i) for i in range(N)]
+    )
+    var = pd.DataFrame(
+        index=["gene{:03d}".format(i) for i in range(N)]
+    )
+    return anndata.AnnData(X, obs=obs, var=var)
+
+
+def test_assigmnent_dict(adata):
+    d_obsp = {
+        "a": pd.DataFrame(
+            np.ones((M, M)),
+            columns=adata.obs_names,
+            index=adata.obs_names
+        ),
+        "b": np.zeros((M, M)),
+        "c": sparse.random(M, M, format="csr")
+    }
+    d_varp = {
+        "a": pd.DataFrame(
+            np.ones((N, N)),
+            columns=adata.var_names,
+            index=adata.var_names
+        ),
+        "b": np.zeros((N, N)),
+        "c": sparse.random(N, N, format="csr")
+    }
+    adata.obsp = d_obsp
+    for k, v in d_obsp.items():
+        assert np.all(asarray(adata.obsp[k]) == asarray(v))
+    adata.varp = d_varp
+    for k, v in d_varp.items():
+        assert np.all(asarray(adata.varp[k]) == asarray(v))
+
+
+def test_setting_ndarray(adata):
+    adata.obsp["a"] = np.ones((M, M))
+    adata.varp["a"] = np.ones((N, N))
+    assert np.all(adata.obsp["a"] == np.ones((M, M)))
+    assert np.all(adata.varp["a"] == np.ones((N, N)))
+
+    h = joblib.hash(adata)
+    with pytest.raises(ValueError):
+        adata.obsp["b"] = np.ones((int(M / 2), M))
+    with pytest.raises(ValueError):
+        adata.obsp["b"] = np.ones((M, int(M * 2)))
+    with pytest.raises(ValueError):
+        adata.varp["b"] = np.ones((int(N / 2), 10))
+    with pytest.raises(ValueError):
+        adata.varp["b"] = np.ones((N, int(N * 2)))
+    assert h == joblib.hash(adata)
+
+
+def test_setting_sparse(adata):
+    obsp_sparse = sparse.random(M, M)
+    adata.obsp["a"] = obsp_sparse
+    assert np.all((adata.obsp["a"] == obsp_sparse).data)
+
+    varp_sparse = sparse.random(N, N)
+    adata.varp["a"] = varp_sparse
+    assert np.all((adata.varp["a"] == varp_sparse).data)
+
+    h = joblib.hash(adata)
+
+    bad_obsp_sparse = sparse.random(M * 2, M)
+    with pytest.raises(ValueError):
+        adata.obsp["b"] = bad_obsp_sparse
+
+    bad_varp_sparse = sparse.random(N * 2, N)
+    with pytest.raises(ValueError):
+        adata.varp["b"] = bad_varp_sparse
+
+    assert h == joblib.hash(adata)

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -305,6 +305,8 @@ def test_set_subset_varm(adata, subset_func):
 @pytest.mark.parametrize('attr', [
     "obsm",
     "varm",
+    "obsp",
+    "varp",
     "layers"
 ])
 def test_view_failed_delitem(attr):
@@ -324,6 +326,8 @@ def test_view_failed_delitem(attr):
 @pytest.mark.parametrize('attr', [
     "obsm",
     "varm",
+    "obsp",
+    "varp",
     "layers"
 ])
 def test_view_delitem(attr):


### PR DESCRIPTION
Fixes #136

This introduces attributes for pairwise measurements on the observations and variables. Currently mostly for cell-cell graphs, but could also be used for gene correlation graphs.

Thoughts @falexwolf @flying-sheep @Koncopd?