### PR TITLE
Concurrent static analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
   include:
     - name: "static analysis"
       python: "3.7"
+      install: pip install black
       script: black . --check --diff
       after_success: skip
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 dist: xenial
 language: python
 cache: pip
-stages:
-  - name: static analysis
-  - name: test
+matrix:
+  include:
+    - name: "static analysis"
+      python: "3.7"
+      script: black . --check --diff
+      after_success: skip
 python:
   - "3.6"
   - "3.7"
@@ -18,9 +21,3 @@ script:
   - rst2html.py --halt=2 README.rst >/dev/null
 after_success:
   - python-codacy-coverage -r coverage.xml
-jobs:
-  include:
-      - stage: static analysis
-        python: "3.7"
-        script: black . --check --diff
-        after_success: skip


### PR DESCRIPTION
Runs static analysis concurrently with tests, while currently static analysis is run first. This cuts down on total test time, and will always test both correctness and style. Here, static analysis can be  real fast since only black has to be installed.

Similar to https://github.com/theislab/scanpy/pull/846

Fixes #221