### PR TITLE
Unifiy zarr and h5ad backends

### DIFF
--- a/anndata/__init__.py
+++ b/anndata/__init__.py
@@ -1,18 +1,16 @@
 from .core.anndata import AnnData, Raw
+from .h5py import read_h5ad
+from .h5py import read_h5ad as read  # backwards compat / shortcut for default format
 from .readwrite import (
-    read_h5ad,
     read_loom,
     read_hdf,
     read_excel,
     read_umi_tools,
     read_csv,
     read_text,
-    read_mtx,
-    read_zarr,
+    read_mtx
 )
-from .readwrite import (
-    read_h5ad as read,
-)  # backwards compat / shortcut for default format
+from .zarr import read_zarr
 
 __doc__ = """\
 API
@@ -89,9 +87,9 @@ __author__ = ', '.join(
 )
 __email__ = ', '.join(
     [
-        'philipp.angerer@helmholtz-muenchen.de',
-        'f.alex.wolf@gmx.de',
-        # We don’t need all, the main authors are sufficient.
+            'philipp.angerer@helmholtz-muenchen.de',
+            'f.alex.wolf@gmx.de',
+            # We don’t need all, the main authors are sufficient.
     ]
 )
 

--- a/anndata/__init__.py
+++ b/anndata/__init__.py
@@ -1,6 +1,8 @@
 from .core.anndata import AnnData, Raw
 from .h5py import read_h5ad
-from .h5py import read_h5ad as read  # backwards compat / shortcut for default format
+from .h5py import (
+    read_h5ad as read,
+)  # backwards compat / shortcut for default format
 from .readwrite import (
     read_loom,
     read_hdf,
@@ -8,7 +10,7 @@ from .readwrite import (
     read_umi_tools,
     read_csv,
     read_text,
-    read_mtx
+    read_mtx,
 )
 from .zarr import read_zarr
 
@@ -87,9 +89,9 @@ __author__ = ', '.join(
 )
 __email__ = ', '.join(
     [
-            'philipp.angerer@helmholtz-muenchen.de',
-            'f.alex.wolf@gmx.de',
-            # We don’t need all, the main authors are sufficient.
+        'philipp.angerer@helmholtz-muenchen.de',
+        'f.alex.wolf@gmx.de',
+        # We don’t need all, the main authors are sufficient.
     ]
 )
 

--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -43,7 +43,7 @@ from .. import h5py, utils
 from ..utils import Index1D, Index, convert_to_dict, unpack_index
 from ..logging import anndata_logger as logger
 from ..compat import ZarrArray, ZappyArray, DaskArray
-
+import anndata.mapping as adm
 
 class StorageType(Enum):
     Array = np.ndarray
@@ -752,9 +752,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 class_names = ', '.join(
                     c.__name__ for c in StorageType.classes()
                 )
-                raise ValueError(
-                    f'`X` needs to be of one of {class_names}, not {type(X)}.'
-                )
+                # raise ValueError(
+                #     f'`X` needs to be of one of {class_names}, not {type(X)}.'
+                # )
             if shape is not None:
                 raise ValueError(
                     '`shape` needs to be `None` if `X` is not `None`.'
@@ -768,7 +768,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                     X = X.astype(dtype)
             elif isinstance(X, ZarrArray):
                 X = X.astype(dtype)
-            else:  # is np.ndarray or a subclass, convert to true np.ndarray
+            elif not isinstance(X, adm.SparseDataset):  # is np.ndarray or a subclass, convert to true np.ndarray
                 X = np.array(X, dtype, copy=False)
             # data matrix and shape
             self._X = X

--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -45,6 +45,7 @@ from ..logging import anndata_logger as logger
 from ..compat import ZarrArray, ZappyArray, DaskArray
 import anndata.mapping as adm
 
+
 class StorageType(Enum):
     Array = np.ndarray
     Masked = ma.MaskedArray
@@ -768,7 +769,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                     X = X.astype(dtype)
             elif isinstance(X, ZarrArray):
                 X = X.astype(dtype)
-            elif not isinstance(X, adm.SparseDataset):  # is np.ndarray or a subclass, convert to true np.ndarray
+            elif not isinstance(
+                X, adm.SparseDataset
+            ):  # is np.ndarray or a subclass, convert to true np.ndarray
                 X = np.array(X, dtype, copy=False)
             # data matrix and shape
             self._X = X

--- a/anndata/h5py/__init__.py
+++ b/anndata/h5py/__init__.py
@@ -23,9 +23,9 @@ For examples and further information, see this `blog post <https://falexwolf.de/
 """
 from h5py import Dataset, special_dtype
 
+from .h5reader import read_h5ad
 from .h5sparse import Group, File, SparseDataset
 
-from .h5reader import read_h5ad
 # Problem: the H5py intersphinx is broken, and only contains e.g. `Dataset` directly.
 # So we can’t possibly link to it using :class:`Dataset`, since that will always find our version.
 Dataset.__doc__ = """Equivalent to :class:`h5py.Dataset <h5py:Dataset>`."""

--- a/anndata/h5py/h5reader.py
+++ b/anndata/h5py/h5reader.py
@@ -1,0 +1,22 @@
+import anndata.mapping as adm
+
+import anndata.h5py as ah5py
+import os
+
+
+def read_h5ad(filename, backed=None, chunk_size=None):
+    return Reader().read(filename, backed=backed)
+
+
+class Reader(adm.MappingReader):
+
+    def __init__(self):
+        super().__init__(ah5py.Dataset)
+
+    def create_file(self, filename, mode):
+        if mode is None:
+            mode = 'w' if os.path.exists(filename) else 'r'
+        return ah5py.File(filename, mode=mode)
+
+    def close_file(self, f):
+        f.close()

--- a/anndata/h5py/h5reader.py
+++ b/anndata/h5py/h5reader.py
@@ -1,6 +1,6 @@
 import anndata.mapping as adm
 
-import anndata.h5py as ah5py
+from .. import h5py as ah5py
 import os
 
 
@@ -9,7 +9,6 @@ def read_h5ad(filename, backed=None, chunk_size=None):
 
 
 class Reader(adm.MappingReader):
-
     def __init__(self):
         super().__init__(ah5py.Dataset)
 

--- a/anndata/h5py/h5sparse.py
+++ b/anndata/h5py/h5sparse.py
@@ -1,193 +1,40 @@
-# TODO:
-# - think about making all of the below subclasses
-# - think about supporting the COO format
-from collections.abc import Iterable, Mapping
 from os import PathLike
-from typing import Optional, Union, KeysView, NamedTuple
+from typing import Optional
 
 import h5py
 import numpy as np
-import scipy.sparse as ss
-from scipy.sparse import _sparsetools
 
-from ..utils import unpack_index
+import anndata.mapping as adm
 
-from .utils import _chunked_rows
+Dataset = h5py.Dataset
 
 
-class BackedFormat(NamedTuple):
-    format_str: str
-    backed_type: type
-    memory_type: type
+class Group(adm.Group):
+
+    def __init__(self, group, force_dense=False):
+        super().__init__(group, force_dense)
 
 
-class BackedSparseMatrixMixin:
-    """\
-    Mixin class for backed sparse matrices.
-
-    Largely needed for the case `backed_sparse_csr(...)[:]`, since that calls
-    copy on `.data`, `.indices`, and `.indptr`.
-    """
-
-    def copy(self):
-        if isinstance(self.data, h5py.Dataset):
-            return SparseDataset(self.data.parent).value
-        else:
-            return super().copy()
-
-
-class backed_csr_matrix(BackedSparseMatrixMixin, ss.csr_matrix):
-    pass
-
-
-class backed_csc_matrix(BackedSparseMatrixMixin, ss.csc_matrix):
-    pass
-
-
-FORMATS = [
-    BackedFormat("csr", backed_csr_matrix, ss.csr_matrix),
-    BackedFormat("csc", backed_csc_matrix, ss.csc_matrix),
-]
-
-
-def get_format_str(data):
-    for fmt, backed_class, memory_class in FORMATS:
-        if isinstance(data, memory_class):
-            return fmt
-    raise ValueError(f"Data type {type(data)} is not supported.")
-
-
-def get_memory_class(format_str):
-    for fmt, backed_class, memory_class in FORMATS:
-        if format_str == fmt:
-            return memory_class
-    raise ValueError(f"Format string {format_str} is not supported.")
-
-
-def get_backed_class(format_str):
-    for fmt, backed_class, memory_class in FORMATS:
-        if format_str == fmt:
-            return backed_class
-    raise ValueError(f"Format string {format_str} is not supported.")
-
-
-def _load_h5_dataset_as_sparse(sds, chunk_size=6000):
-    # efficient for csr, not so for csc (but still better than loompy it seems)
-    if not isinstance(sds, h5py.Dataset):
-        raise ValueError('sds should be a h5py Dataset')
-
-    if 'sparse_format' in sds.attrs:
-        sparse_class = get_memory_class(sds.attrs['sparse_format'])
-    else:
-        sparse_class = ss.csr_matrix
-
-    data = None
-
-    for chunk, _, _ in _chunked_rows(sds, chunk_size, True):
-        data = (
-            sparse_class(chunk)
-            if data is None
-            else ss.vstack([data, sparse_class(chunk)])
-        )
-
-    return data
-
-
-class Group(Mapping):
-    """\
-    Like :class:`h5py.Group <h5py:Group>`, but able to handle sparse matrices.
-    """
-
-    def __init__(self, h5py_group, force_dense=False):
-        self.h5py_group = h5py_group
-        self.force_dense = force_dense
-
-    def __iter__(self):
-        for k in self.keys():
-            yield k
-
-    def __len__(self):
-        return len(self.h5py_group)
-
-    def __getitem__(
-        self, key: str
-    ) -> Union[h5py.Group, h5py.Dataset, 'SparseDataset']:
-        h5py_item = self.h5py_group[key]
-        if isinstance(h5py_item, h5py.Group):
-            if 'h5sparse_format' in h5py_item.attrs:
-                # detect the sparse matrix
-                return SparseDataset(h5py_item)
-            else:
-                return Group(h5py_item)
-        elif isinstance(h5py_item, h5py.Dataset):
-            return h5py_item
-        else:
-            raise ValueError("Unexpected item type.")
+class SparseDataset(adm.SparseDataset):
+    def __init__(self, group):
+        super().__init__(group)
 
     @property
-    def attrs(self):
-        return self.h5py_group.attrs
-
-    @property
-    def name(self):
-        return self.h5py_group.name
-
-    def __delitem__(self, name):
-        self.h5py_group.__delitem__(name)
-
-    def __setitem__(
-        self, key: str, value: Union[h5py.Group, h5py.Dataset, 'SparseDataset']
-    ):
-        self.h5py_group.__setitem__(key, value)
-
-    def keys(self) -> KeysView[str]:
-        return self.h5py_group.keys()
-
-    def create_dataset(self, name, data=None, chunk_size=6000, **kwargs):
-        if data is None:
-            raise NotImplementedError(
-                "`create_dataset` is only supported if `data` is passed."
-            )
-        if not isinstance(data, SparseDataset) and not ss.issparse(data):
-            return self.h5py_group.create_dataset(
-                name=name, data=data, **kwargs
-            )
-        if self.force_dense:
-            sds = self.h5py_group.create_dataset(
-                name=name, shape=data.shape, dtype=data.dtype, **kwargs
-            )
-            for chunk, start, end in _chunked_rows(data, chunk_size):
-                sds[start:end] = chunk.toarray()
-            sds.attrs['sparse_format'] = (
-                data.format_str
-                if isinstance(data, SparseDataset)
-                else get_format_str(data)
-            )
-            return sds
-        # SparseDataset or spmatrix
-        group = self.h5py_group.create_group(name)
-        if isinstance(data, SparseDataset):
-            for attr in ['h5sparse_format', 'h5sparse_shape']:
-                group.attrs[attr] = data.h5py_group.attrs[attr]
-            get_dataset = data.h5py_group.__getitem__
-        else:  # ss.issparse(data):
-            group.attrs['h5sparse_format'] = get_format_str(data)
-            group.attrs['h5sparse_shape'] = data.shape
-            get_dataset = lambda d: getattr(data, d)
-        for dataset in ['data', 'indices', 'indptr']:
-            group.create_dataset(
-                dataset, data=get_dataset(dataset), maxshape=(None,), **kwargs
-            )
-        return SparseDataset(group)
-
-    def create_group(self, name, track_order=None):
-        return Group(
-            self.h5py_group.create_group(name, track_order=track_order)
+    def value(self):
+        format_class = adm.get_memory_class(self.format_str, self.__class__.FORMATS)
+        object = self.group
+        data_array = format_class(self.shape, dtype=self.dtype)
+        data_array.data = np.empty(object['data'].shape, object['data'].dtype)
+        data_array.indices = np.empty(
+            object['indices'].shape, object['indices'].dtype
         )
-
-
-Group.create_dataset.__doc__ = h5py.Group.create_dataset.__doc__
-Group.create_group.__doc__ = h5py.Group.create_group.__doc__
+        data_array.indptr = np.empty(
+            object['indptr'].shape, object['indptr'].dtype
+        )
+        object['data'].read_direct(data_array.data)
+        object['indices'].read_direct(data_array.indices)
+        object['indptr'].read_direct(data_array.indptr)
+        return data_array
 
 
 class File(Group):
@@ -196,15 +43,15 @@ class File(Group):
     """
 
     def __init__(
-        self,
-        name: PathLike,
-        mode: Optional[str] = None,
-        driver: Optional[str] = None,
-        libver: Optional[str] = None,
-        userblock_size: Optional[int] = None,
-        swmr: bool = False,
-        force_dense: bool = False,
-        **kwds,
+            self,
+            name: PathLike,
+            mode: Optional[str] = None,
+            driver: Optional[str] = None,
+            libver: Optional[str] = None,
+            userblock_size: Optional[int] = None,
+            swmr: bool = False,
+            force_dense: bool = False,
+            **kwds,
     ):
         self.h5f = h5py.File(
             name,
@@ -212,13 +59,17 @@ class File(Group):
             driver=driver,
             libver=libver,
             userblock_size=userblock_size,
-            swmr=swmr,
-            **kwds,
+            swmr=swmr
         )
         super().__init__(self.h5f, force_dense)
 
     def __enter__(self):
         return self
+
+    def close(self):
+        """Close the backing file, remember filename, do *not* change to memory mode."""
+        if self._file is not None:
+            self._file.close()
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.h5f.__exit__(exc_type, exc_value, traceback)
@@ -237,198 +88,8 @@ class File(Group):
 
 File.__init__.__doc__ = h5py.File.__init__.__doc__
 
+adm.add_mapping_impl(h5py.Dataset, h5py.Group, 'h5sparse_format', 'h5sparse_shape', Group, SparseDataset, [File,
+                                                                                                           Dataset])
 
-def _set_many(self, i, j, x):
-    """\
-    Sets value at each (i, j) to x
-
-    Here (i,j) index major and minor respectively, and must not contain
-    duplicate entries.
-    """
-    i, j, M, N = self._prepare_indices(i, j)
-
-    if np.isscalar(x):  # Scipy 1.3+ compat
-        n_samples = 1
-    else:
-        n_samples = len(x)
-    offsets = np.empty(n_samples, dtype=self.indices.dtype)
-    ret = _sparsetools.csr_sample_offsets(
-        M, N, self.indptr, self.indices, n_samples, i, j, offsets
-    )
-    if ret == 1:
-        # rinse and repeat
-        self.sum_duplicates()
-        _sparsetools.csr_sample_offsets(
-            M, N, self.indptr, self.indices, n_samples, i, j, offsets
-        )
-
-    if -1 not in offsets:
-        # make a list for interaction with h5py
-        offsets = list(offsets)
-        # only affects existing non-zero cells
-        self.data[offsets] = x
-        return
-
-    else:
-        raise ValueError(
-            'Currently, you cannot change the sparsity structure of a SparseDataset.'
-        )
-        # replace where possible
-        # mask = offsets > -1
-        # # offsets[mask]
-        # bool_data_mask = np.zeros(len(self.data), dtype=bool)
-        # bool_data_mask[offsets[mask]] = True
-        # self.data[bool_data_mask] = x[mask]
-        # # self.data[offsets[mask]] = x[mask]
-        # # only insertions remain
-        # mask = ~mask
-        # i = i[mask]
-        # i[i < 0] += M
-        # j = j[mask]
-        # j[j < 0] += N
-        # self._insert_many(i, j, x[mask])
-
-
-backed_csr_matrix._set_many = _set_many
-backed_csc_matrix._set_many = _set_many
-
-
-def _zero_many(self, i, j):
-    """\
-    Sets value at each (i, j) to zero, preserving sparsity structure.
-
-    Here (i,j) index major and minor respectively.
-    """
-    i, j, M, N = self._prepare_indices(i, j)
-
-    n_samples = len(i)
-    offsets = np.empty(n_samples, dtype=self.indices.dtype)
-    ret = _sparsetools.csr_sample_offsets(
-        M, N, self.indptr, self.indices, n_samples, i, j, offsets
-    )
-    if ret == 1:
-        # rinse and repeat
-        self.sum_duplicates()
-        _sparsetools.csr_sample_offsets(
-            M, N, self.indptr, self.indices, n_samples, i, j, offsets
-        )
-
-    # only assign zeros to the existing sparsity structure
-    self.data[list(offsets[offsets > -1])] = 0
-
-
-backed_csr_matrix._zero_many = _zero_many
-backed_csc_matrix._zero_many = _zero_many
-
-
-class SparseDataset:
-    """\
-    Analogous to :class:`h5py.Dataset <h5py:Dataset>`, but for sparse matrices.
-    """
-
-    def __init__(self, h5py_group):
-        self.h5py_group = h5py_group
-
-    def __repr__(self):
-        return (
-            f'<HDF5 sparse dataset: format {self.format_str!r}, '
-            f'shape {self.shape}, '
-            f'type {self.h5py_group["data"].dtype.str!r}>'
-        )
-
-    @property
-    def format_str(self):
-        return self.h5py_group.attrs['h5sparse_format']
-
-    def __getitem__(self, index):
-        if index == ():
-            index = slice(None)
-        row, col = unpack_index(index)
-        if all(isinstance(x, Iterable) for x in (row, col)):
-            row, col = np.ix_(row, col)
-        format_class = get_backed_class(self.format_str)
-        mock_matrix = format_class(self.shape, dtype=self.dtype)
-        mock_matrix.data = self.h5py_group['data']
-        mock_matrix.indices = self.h5py_group['indices']
-        mock_matrix.indptr = self.h5py_group['indptr']
-        return mock_matrix[row, col]
-
-    def __setitem__(self, index, value):
-        if index == ():
-            index = slice(None)
-        row, col = unpack_index(index)
-        if all(isinstance(x, Iterable) for x in (row, col)):
-            row, col = np.ix_(row, col)
-        format_class = get_backed_class(self.format_str)
-        mock_matrix = format_class(self.shape, dtype=self.dtype)
-        mock_matrix.data = self.h5py_group['data']
-        mock_matrix.indices = self.h5py_group['indices']
-        mock_matrix.indptr = self.h5py_group['indptr']
-        mock_matrix[row, col] = value
-
-    @property
-    def shape(self):
-        return tuple(self.h5py_group.attrs['h5sparse_shape'])
-
-    @property
-    def dtype(self):
-        return self.h5py_group['data'].dtype
-
-    @property
-    def value(self):
-        format_class = get_memory_class(self.format_str)
-        object = self.h5py_group
-        data_array = format_class(self.shape, dtype=self.dtype)
-        data_array.data = np.empty(object['data'].shape, object['data'].dtype)
-        data_array.indices = np.empty(
-            object['indices'].shape, object['indices'].dtype
-        )
-        data_array.indptr = np.empty(
-            object['indptr'].shape, object['indptr'].dtype
-        )
-        object['data'].read_direct(data_array.data)
-        object['indices'].read_direct(data_array.indices)
-        object['indptr'].read_direct(data_array.indptr)
-        return data_array
-
-    def append(self, sparse_matrix):
-        shape = self.h5py_group.attrs['h5sparse_shape']
-
-        if self.format_str != get_format_str(sparse_matrix):
-            raise ValueError("Format not the same.")
-
-        if self.format_str != 'csr':
-            raise NotImplementedError(
-                f"The append method for format {self.format_str} "
-                f"is not implemented."
-            )
-
-        # data
-        data = self.h5py_group['data']
-        orig_data_size = data.shape[0]
-        new_shape = (orig_data_size + sparse_matrix.data.shape[0],)
-        data.resize(new_shape)
-        data[orig_data_size:] = sparse_matrix.data
-
-        # indptr
-        indptr = self.h5py_group['indptr']
-        orig_data_size = indptr.shape[0]
-        append_offset = indptr[-1]
-        new_shape = (orig_data_size + sparse_matrix.indptr.shape[0] - 1,)
-        indptr.resize(new_shape)
-        indptr[orig_data_size:] = (
-            sparse_matrix.indptr[1:].astype(np.int64) + append_offset
-        )
-
-        # indices
-        indices = self.h5py_group['indices']
-        orig_data_size = indices.shape[0]
-        new_shape = (orig_data_size + sparse_matrix.indices.shape[0],)
-        indices.resize(new_shape)
-        indices[orig_data_size:] = sparse_matrix.indices
-
-        # shape
-        self.h5py_group.attrs['h5sparse_shape'] = (
-            shape[0] + sparse_matrix.shape[0],
-            max(shape[1], sparse_matrix.shape[1]),
-        )
+Group.create_dataset.__doc__ = h5py.Group.create_dataset.__doc__
+Group.create_group.__doc__ = h5py.Group.create_group.__doc__

--- a/anndata/h5py/h5sparse.py
+++ b/anndata/h5py/h5sparse.py
@@ -4,13 +4,12 @@ from typing import Optional
 import h5py
 import numpy as np
 
-import anndata.mapping as adm
+from .. import mapping as adm
 
 Dataset = h5py.Dataset
 
 
 class Group(adm.Group):
-
     def __init__(self, group, force_dense=False):
         super().__init__(group, force_dense)
 
@@ -21,7 +20,9 @@ class SparseDataset(adm.SparseDataset):
 
     @property
     def value(self):
-        format_class = adm.get_memory_class(self.format_str, self.__class__.FORMATS)
+        format_class = adm.get_memory_class(
+            self.format_str, self.__class__.FORMATS
+        )
         object = self.group
         data_array = format_class(self.shape, dtype=self.dtype)
         data_array.data = np.empty(object['data'].shape, object['data'].dtype)
@@ -43,15 +44,15 @@ class File(Group):
     """
 
     def __init__(
-            self,
-            name: PathLike,
-            mode: Optional[str] = None,
-            driver: Optional[str] = None,
-            libver: Optional[str] = None,
-            userblock_size: Optional[int] = None,
-            swmr: bool = False,
-            force_dense: bool = False,
-            **kwds,
+        self,
+        name: PathLike,
+        mode: Optional[str] = None,
+        driver: Optional[str] = None,
+        libver: Optional[str] = None,
+        userblock_size: Optional[int] = None,
+        swmr: bool = False,
+        force_dense: bool = False,
+        **kwds,
     ):
         self.h5f = h5py.File(
             name,
@@ -59,7 +60,7 @@ class File(Group):
             driver=driver,
             libver=libver,
             userblock_size=userblock_size,
-            swmr=swmr
+            swmr=swmr,
         )
         super().__init__(self.h5f, force_dense)
 
@@ -88,8 +89,15 @@ class File(Group):
 
 File.__init__.__doc__ = h5py.File.__init__.__doc__
 
-adm.add_mapping_impl(h5py.Dataset, h5py.Group, 'h5sparse_format', 'h5sparse_shape', Group, SparseDataset, [File,
-                                                                                                           Dataset])
+adm.add_mapping_impl(
+    h5py.Dataset,
+    h5py.Group,
+    'h5sparse_format',
+    'h5sparse_shape',
+    Group,
+    SparseDataset,
+    [File, Dataset],
+)
 
 Group.create_dataset.__doc__ = h5py.Group.create_dataset.__doc__
 Group.create_group.__doc__ = h5py.Group.create_group.__doc__

--- a/anndata/mapping/__init__.py
+++ b/anndata/mapping/__init__.py
@@ -1,11 +1,11 @@
 """Wraps `h5py <http://www.h5py.org/>`_ to handle sparse matrices.
 
-:mod:`anndata.h5py` is based on and uses the conventions of
+:mod:`anndata.mapping` is based on and uses the conventions of
 `h5sparse <https://github.com/appier/h5sparse>`_ by
 `Appier Inc. <https://www.appier.com/>`_.
 See the copyright and license note in the source code.
 
-The design choices of :mod:`anndata.h5py`, however, are different. In
+The design choices of :mod:`anndata.mapping`, however, are different. In
 particular, :mod:`anndata.h5py` allows handling sparse and non-sparse data at
 the same time. It achieves this by extending the functionality of :class:`File`
 and :class:`Group` objects in the h5py API, and by providing a new
@@ -16,16 +16,11 @@ For examples and further information, see this `blog post <https://falexwolf.de/
 .. autosummary::
   :toctree: .
 
-   File
    Group
    Dataset
    SparseDataset
 """
-from h5py import Dataset, special_dtype
+from .sparse_mapping import get_memory_class, add_mapping_impl
+from .sparse_mapping import Group, SparseDataset
 
-from .h5sparse import Group, File, SparseDataset
-
-from .h5reader import read_h5ad
-# Problem: the H5py intersphinx is broken, and only contains e.g. `Dataset` directly.
-# So we can’t possibly link to it using :class:`Dataset`, since that will always find our version.
-Dataset.__doc__ = """Equivalent to :class:`h5py.Dataset <h5py:Dataset>`."""
+from .mapping_reader import MappingReader, report_key_on_error, AnnDataReadError

--- a/anndata/mapping/mapping_reader.py
+++ b/anndata/mapping/mapping_reader.py
@@ -1,0 +1,211 @@
+from functools import wraps
+from pathlib import Path
+from typing import Optional
+from typing import Union
+
+import numpy as np
+import pandas as pd
+from scipy import sparse
+
+import anndata as ad
+import anndata.mapping as adm
+from anndata.compat import _clean_uns
+from anndata.compat import _from_fixed_length_strings
+
+
+class AnnDataReadError(OSError):
+    """Error caused while trying to read in AnnData."""
+
+    pass
+
+
+def report_key_on_error(func):
+    """
+    A decorator for zarr or hdf5 element reading which makes keys involved in errors get reported.
+
+    Example
+    -------
+    >>> import zarr
+    >>> @report_key_on_error
+    ... def read_arr(group):
+    ...     raise NotImplementedError()
+    >>> z = zarr.open("tmp.zarr")
+    >>> z["X"] = [1, 2, 3]
+    >>> read_arr(z["X"])
+    """
+
+    @wraps(func)
+    def func_wrapper(elem, *args, **kwargs):
+        try:
+            return func(elem, *args, **kwargs)
+        except Exception as e:
+            if isinstance(e, AnnDataReadError):
+                raise e
+            else:
+                raise AnnDataReadError(
+                    str(e)
+                )
+
+    return func_wrapper
+
+
+class MappingReader:
+
+    def __init__(self, dataset_class):
+        self.dataset_class = dataset_class
+
+    def create_file(self, filename, mode):
+        pass
+
+    def close_file(self, f):
+        pass
+
+    def read_attribute(self, value):
+        if isinstance(value, adm.SparseDataset):
+            return self.read_sparse_dataset(value)
+        elif isinstance(value, self.dataset_class):
+            return self.read_dataset(value)
+        elif isinstance(value, adm.Group):
+            return self.read_group(value)
+        elif value is None:
+            return None
+
+        raise NotImplementedError(str(type(value)) + ' ' + str(value))
+
+    @report_key_on_error
+    def read_dataframe_legacy(self, dataset) -> pd.DataFrame:
+        """
+        Read pre-anndata 0.7 dataframes.
+        """
+        df = pd.DataFrame(_from_fixed_length_strings(dataset[()]))
+        df.set_index(df.columns[0], inplace=True)
+        return df
+
+    @report_key_on_error
+    def read_dataframe(self, group) -> pd.DataFrame:
+        if not isinstance(group, adm.Group):
+            return self.read_dataframe_legacy(group)
+        df = pd.DataFrame({k: self.read_series(group[k]) for k in group.keys()})
+        df.set_index(group.attrs["_index"], inplace=True)
+        if group.attrs["_index"] == "_index":
+            df.index.name = None
+        if "column-order" in group.attrs:  # TODO: Should this be optional?
+            assert set(group.attrs["column-order"]) == set(df.columns)
+            df = df[group.attrs["column-order"]]
+        return df
+
+    @report_key_on_error
+    def read_series(self, dataset) -> Union[np.ndarray, pd.Categorical]:
+        if "categories" in dataset.attrs:
+            return pd.Categorical.from_codes(
+                dataset[...], dataset.attrs["categories"], ordered=False
+            )
+        else:
+            return dataset[...]
+
+    @report_key_on_error
+    def read_group(self, group: adm.Group) -> Union[dict, pd.DataFrame]:
+        if group.attrs.get("encoding-type", "") == "dataframe":
+            return self.read_dataframe(group)
+        d = dict()
+        for sub_key, sub_value in group.items():
+            d[sub_key] = self.read_attribute(sub_value)
+        return d
+
+    @report_key_on_error
+    def read_dataset(self, dataset: 'Dataset'):
+
+        value = dataset[()]
+        if not hasattr(value, "dtype"):
+            return value
+        elif isinstance(value.dtype, str):
+            pass
+        elif issubclass(value.dtype.type, np.string_):
+            value = value.astype(str)
+            if (
+                    len(value) == 1
+            ):  # Backwards compat, old datasets have strings written as one element 1d arrays
+                return value[0]
+        elif len(value.dtype.descr) > 1:  # Compound dtype
+            value = _from_fixed_length_strings(
+                value
+            )  # For backwards compat, now strings are written as variable length
+        if value.shape == ():
+            value = value[()]
+        return value
+
+    @report_key_on_error
+    def read_sparse_dataset(self, value) -> sparse.spmatrix:
+        return value.value
+
+    def read(self, filename: Union[str, Path], backed: Optional[Union[str, bool]] = None) -> 'AnnData':
+        """Read ``.h5ad`` and ``.zarr`` formatted hdf5 file.
+
+        Parameters
+        ----------
+        filename
+            File name of data file.
+        backed : {``None``, ``'r'``, ``'r+'``}
+            If ``'r'``, load :class:`~anndata.AnnData` in ``backed`` mode instead
+            of fully loading it into memory (`memory` mode). If you want to modify
+            backed attributes of the AnnData object, you need to choose ``'r+'``.
+        chunk_size
+            Used only when loading sparse dataset that is stored as dense.
+            Loading iterates through chunks of the dataset of this row size
+            until it reads the whole dataset.
+            Higher size means higher memory consumption and higher loading speed.
+        """
+        mode = None
+        d = {}
+        if backed not in {None, False}:
+            mode = backed
+            if mode is True:
+                mode = "r+"
+            assert mode in {"r", "r+"}
+
+        raw = {}
+
+        f = self.create_file(filename, mode if mode is not None else 'r')
+        import anndata.zarr
+        if mode is not None and not isinstance(f, anndata.zarr.File):
+            # FIXME passing the filename only works for h5 files
+            d = {"filename": filename, "filemode": mode}
+        attributes = ["obsm", "varm", "obsp", "varp", "uns", "layers"]
+        if mode is None:
+            attributes.append('X')
+
+        df_attributes = ["obs", "var"]
+
+        d.update({k: self.read_attribute(f[k]) for k in attributes if k in f})
+        for k in df_attributes:
+            if k in f:  # Backwards compat
+                d[k] = self.read_dataframe(f[k])
+
+        if "raw" in f:
+            if "raw/var" in f:
+                raw["var"] = self.read_attribute(f["raw/var"])
+            if "raw/varm" in f:
+                raw["varm"] = self.read_attribute(f["raw/varm"])
+            if mode is None and "raw/X" in f:
+                raw["X"] = self.read_attribute(f["raw/X"])
+        else:  # Legacy case
+            if "raw.var" in f:
+                raw["var"] = self.read_dataframe(f["raw.var"])  # Backwards compat
+            if "raw.varm" in f:
+                raw["varm"] = self.read_attribute(f["raw.varm"])
+            if mode is None and "raw.X" in f:
+                raw["X"] = self.read_attribute(f["raw.X"])
+        if mode is not None and isinstance(f, anndata.zarr.File):
+            # FIXME, backing manager only supports h5 files
+            d['X'] = f['X']
+        if len(raw) > 0:
+            d["raw"] = raw
+
+        if "X" in d:
+            d["dtype"] = d["X"].dtype
+
+        _clean_uns(d)
+        if mode is not None and not isinstance(f, anndata.zarr.File):
+            # FIXME, file will be opened again by backing manager
+            self.close_file(f)
+        return ad.AnnData(**d)

--- a/anndata/mapping/sparse_mapping.py
+++ b/anndata/mapping/sparse_mapping.py
@@ -1,0 +1,358 @@
+# TODO:
+# - think about supporting the COO format
+from collections.abc import Iterable, Mapping
+from typing import Union, KeysView, NamedTuple
+
+import numpy as np
+import scipy.sparse as ss
+from scipy.sparse import _sparsetools
+
+from anndata.h5py.utils import _chunked_rows
+from anndata.utils import unpack_index
+
+
+def create_formats(dataset_class, sparse_dataset_wrapper_class):
+    class BackedSparseMatrixMixin:
+        """\
+        Mixin class for backed sparse matrices.
+
+        Largely needed for the case `backed_sparse_csr(...)[:]`, since that calls
+        copy on `.data`, `.indices`, and `.indptr`.
+        """
+
+        def copy(self):
+            if isinstance(self.data, dataset_class):
+                return sparse_dataset_wrapper_class(self.data.parent).value
+            else:
+                return super().copy()
+
+    class backed_csr_matrix(BackedSparseMatrixMixin, ss.csr_matrix):
+        pass
+
+    class backed_csc_matrix(BackedSparseMatrixMixin, ss.csc_matrix):
+        pass
+
+    backed_csr_matrix._set_many = _set_many
+    backed_csc_matrix._set_many = _set_many
+    backed_csr_matrix._zero_many = _zero_many
+    backed_csc_matrix._zero_many = _zero_many
+
+    return [
+            BackedFormat("csr_matrix", backed_csr_matrix, ss.csr_matrix),
+            BackedFormat("csr", backed_csr_matrix, ss.csr_matrix),
+            BackedFormat("csc", backed_csc_matrix, ss.csc_matrix),
+            BackedFormat("csc_matrix", backed_csc_matrix, ss.csc_matrix)
+    ]
+
+
+class BackedFormat(NamedTuple):
+    format_str: str
+    backed_type: type
+    memory_type: type
+
+
+def add_mapping_impl(dataset_impl_class, group_impl_class, X_encoding_attr_key, X_shape_attr_key, group_wrapper_class,
+                     sparse_dataset_wrapper_class, additional_wrapper_classes):
+    formats = create_formats(dataset_impl_class, sparse_dataset_wrapper_class)
+    wrapper_classes = [sparse_dataset_wrapper_class, group_wrapper_class] + additional_wrapper_classes
+    for c in wrapper_classes:
+        c.FORMATS = formats
+        c.X_ENCODING_FORMAT_ATTR = X_encoding_attr_key
+        c.X_SHAPE_ATTR = X_shape_attr_key
+        c.GROUP_WRAPPER_CLASS = group_wrapper_class
+        c.DATASET_CLASS = dataset_impl_class
+        c.GROUP_CLASS = group_impl_class
+        c.SPARSE_DATASET_WRAPPER_CLASS = sparse_dataset_wrapper_class
+
+
+def get_format_str(data, formats):
+    for fmt, backed_class, memory_class in formats:
+        if isinstance(data, memory_class):
+            return fmt
+    raise ValueError(f"Data type {type(data)} is not supported.")
+
+
+def get_memory_class(format_str, formats):
+    for fmt, backed_class, memory_class in formats:
+        if format_str == fmt:
+            return memory_class
+    raise ValueError(f"Format string {format_str} is not supported.")
+
+
+def get_backed_class(format_str, formats):
+    for fmt, backed_class, memory_class in formats:
+        if format_str == fmt:
+            return backed_class
+    raise ValueError(f"Format string {format_str} is not supported.")
+
+
+# def _load_dataset_as_sparse(sds, chunk_size=6000):
+#     # efficient for csr, not so for csc (but still better than loompy it seems)
+#     if 'sparse_format' in sds.attrs:
+#         sparse_class = get_memory_class(sds.attrs['sparse_format'])
+#     else:
+#         sparse_class = ss.csr_matrix
+#
+#     data = None
+#
+#     for chunk, _, _ in _chunked_rows(sds, chunk_size, True):
+#         data = (
+#                 sparse_class(chunk)
+#                 if data is None
+#                 else ss.vstack([data, sparse_class(chunk)])
+#         )
+#
+#     return data
+
+
+class Group(Mapping):
+    """\
+    Like :class:`h5py.Group <h5py:Group>`, but able to handle sparse matrices.
+    """
+
+    def __init__(self, group, force_dense=False):
+        self.group = group
+        self.force_dense = force_dense
+
+    def __iter__(self):
+        for k in self.keys():
+            yield k
+
+    def __len__(self):
+        return len(self.group)
+
+    def __getitem__(
+            self, key: str
+    ) -> Union['h5py.Group', 'h5py.Dataset', 'zarr.core.Array', 'zarr.hierarchy.Group', 'SparseDataset']:
+        item = self.group[key]
+        if isinstance(item, self.__class__.GROUP_CLASS):
+            encoding = item.attrs.get(self.__class__.X_ENCODING_FORMAT_ATTR, '')
+            if encoding == 'csr_matrix' or encoding == 'csc_matrix' or encoding == 'csr' or encoding == 'csc':
+                return self.__class__.SPARSE_DATASET_WRAPPER_CLASS(item)
+            else:
+                return self.__class__.GROUP_WRAPPER_CLASS(item)
+        elif isinstance(item, self.__class__.DATASET_CLASS):
+            return item
+        else:
+            raise ValueError("Unexpected item type.")
+
+    def create_group(self, name):
+        return self.__class__.GROUP_WRAPPER_CLASS(self.group.create_group(name))
+
+    @property
+    def attrs(self):
+        return self.group.attrs
+
+    @property
+    def name(self):
+        return self.group.name
+
+    def __delitem__(self, name):
+        self.group.__delitem__(name)
+
+    def __setitem__(self, key: str, value: Union[
+        'h5py.Group', 'h5py.Dataset', 'zarr.hierarchy.Group', 'zarr.core.Array', 'SparseDataset']):
+        self.group.__setitem__(key, value)
+
+    def keys(self) -> KeysView[str]:
+        return self.group.keys()
+
+    def create_dataset(self, name, data=None, chunk_size=6000, **kwargs):
+        if data is None:
+            raise NotImplementedError(
+                "`create_dataset` is only supported if `data` is passed."
+            )
+        if not isinstance(data, SparseDataset) and not ss.issparse(data):
+            return self.group.create_dataset(
+                name=name, data=data, **kwargs
+            )
+        if self.force_dense:
+            sds = self.group.create_dataset(
+                name=name, shape=data.shape, dtype=data.dtype, **kwargs
+            )
+            for chunk, start, end in _chunked_rows(data, chunk_size):
+                sds[start:end] = chunk.toarray()
+            sds.attrs['sparse_format'] = (
+                    data.format_str
+                    if isinstance(data, SparseDataset)
+                    else get_format_str(data, self.__class__.FORMATS)
+            )
+            return sds
+        # SparseDataset or spmatrix
+        group = self.group.create_group(name)
+        if isinstance(data, SparseDataset):
+            for attr in [self.__class__.X_ENCODING_FORMAT_ATTR, self.__class__.X_SHAPE_ATTR]:
+                group.attrs[attr] = data.group.attrs[attr]
+            get_dataset = data.group.__getitem__
+        else:  # ss.issparse(data):
+            group.attrs[self.__class__.X_ENCODING_FORMAT_ATTR] = get_format_str(data, self.__class__.FORMATS)
+            group.attrs[self.__class__.X_SHAPE_ATTR] = data.shape
+            get_dataset = lambda d: getattr(data, d)
+        for dataset in ['data', 'indices', 'indptr']:
+            group.create_dataset(
+                dataset, data=get_dataset(dataset), maxshape=(None,), **kwargs
+            )
+        return self.__class__.SPARSE_DATASET_WRAPPER_CLASS(group)
+
+
+def _set_many(self, i, j, x):
+    """\
+    Sets value at each (i, j) to x
+
+    Here (i,j) index major and minor respectively, and must not contain
+    duplicate entries.
+    """
+    i, j, M, N = self._prepare_indices(i, j)
+
+    if np.isscalar(x):  # Scipy 1.3+ compat
+        n_samples = 1
+    else:
+        n_samples = len(x)
+    offsets = np.empty(n_samples, dtype=self.indices.dtype)
+    ret = _sparsetools.csr_sample_offsets(
+        M, N, self.indptr, self.indices, n_samples, i, j, offsets
+    )
+    if ret == 1:
+        # rinse and repeat
+        self.sum_duplicates()
+        _sparsetools.csr_sample_offsets(
+            M, N, self.indptr, self.indices, n_samples, i, j, offsets
+        )
+
+    if -1 not in offsets:
+        # make a list for interaction with h5py
+        offsets = list(offsets)
+        # only affects existing non-zero cells
+        self.data[offsets] = x
+        return
+
+    else:
+        raise ValueError(
+            'Currently, you cannot change the sparsity structure of a AbstractSparseDataset.'
+        )
+        # replace where possible
+        # mask = offsets > -1
+        # # offsets[mask]
+        # bool_data_mask = np.zeros(len(self.data), dtype=bool)
+        # bool_data_mask[offsets[mask]] = True
+        # self.data[bool_data_mask] = x[mask]
+        # # self.data[offsets[mask]] = x[mask]
+        # # only insertions remain
+        # mask = ~mask
+        # i = i[mask]
+        # i[i < 0] += M
+        # j = j[mask]
+        # j[j < 0] += N
+        # self._insert_many(i, j, x[mask])
+
+
+def _zero_many(self, i, j):
+    """\
+    Sets value at each (i, j) to zero, preserving sparsity structure.
+
+    Here (i,j) index major and minor respectively.
+    """
+    i, j, M, N = self._prepare_indices(i, j)
+
+    n_samples = len(i)
+    offsets = np.empty(n_samples, dtype=self.indices.dtype)
+    ret = _sparsetools.csr_sample_offsets(
+        M, N, self.indptr, self.indices, n_samples, i, j, offsets
+    )
+    if ret == 1:
+        # rinse and repeat
+        self.sum_duplicates()
+        _sparsetools.csr_sample_offsets(
+            M, N, self.indptr, self.indices, n_samples, i, j, offsets
+        )
+
+    # only assign zeros to the existing sparsity structure
+    self.data[list(offsets[offsets > -1])] = 0
+
+
+class SparseDataset:
+    """\
+    Analogous to :class:`h5py.Dataset <h5py:Dataset>`, but for sparse matrices.
+    """
+
+    def __init__(self, group):
+        self.group = group
+
+    @property
+    def value(self):
+        pass
+
+    @property
+    def format_str(self):
+        return self.group.attrs[self.__class__.X_ENCODING_FORMAT_ATTR]
+
+    def _get_mock_matrix(self, index):
+        if index == ():
+            index = slice(None)
+        row, col = unpack_index(index)
+        if all(isinstance(x, Iterable) for x in (row, col)):
+            row, col = np.ix_(row, col)
+        format_class = get_backed_class(self.format_str, self.__class__.FORMATS)
+        mock_matrix = format_class(self.shape, dtype=self.dtype)
+        mock_matrix.data = self.group['data']
+        mock_matrix.indices = self.group['indices']
+        mock_matrix.indptr = self.group['indptr']
+        return mock_matrix, row, col
+
+    def __getitem__(self, index):
+        mock_matrix, row, col = self._get_mock_matrix(index)
+        return mock_matrix[row, col]
+
+    def __setitem__(self, index, value):
+        mock_matrix, row, col = self._get_mock_matrix(index)
+        mock_matrix[row, col] = value
+
+    @property
+    def shape(self):
+        return tuple(self.group.attrs[self.__class__.X_SHAPE_ATTR])
+
+    @property
+    def dtype(self):
+        return self.group['data'].dtype
+
+    def append(self, sparse_matrix):
+        shape = self.group.attrs[self.__class__.X_SHAPE_ATTR]
+
+        if self.format_str != get_format_str(sparse_matrix, self.__class__.FORMATS):
+            raise ValueError("Format not the same.")
+
+        if self.format_str != 'csr' and self.format_str != 'csr_matrix':
+            raise NotImplementedError(
+                f"The append method for format {self.format_str} "
+                f"is not implemented."
+            )
+
+        # data
+        data = self.group['data']
+        orig_data_size = data.shape[0]
+        new_shape = (orig_data_size + sparse_matrix.data.shape[0],)
+        data.resize(new_shape)
+        data[orig_data_size:] = sparse_matrix.data
+
+        # indptr
+        indptr = self.group['indptr']
+        orig_data_size = indptr.shape[0]
+        append_offset = indptr[-1]
+        new_shape = (orig_data_size + sparse_matrix.indptr.shape[0] - 1,)
+        indptr.resize(new_shape)
+        indptr[orig_data_size:] = (
+                sparse_matrix.indptr[1:].astype(np.int64) + append_offset
+        )
+
+        # indices
+        indices = self.group['indices']
+        orig_data_size = indices.shape[0]
+        new_shape = (orig_data_size + sparse_matrix.indices.shape[0],)
+        indices.resize(new_shape)
+        indices[orig_data_size:] = sparse_matrix.indices
+
+        # shape
+        self.group.attrs[self.__class__.X_SHAPE_ATTR] = (
+                shape[0] + sparse_matrix.shape[0],
+                max(shape[1], sparse_matrix.shape[1]),
+        )

--- a/anndata/readwrite/zarr.py
+++ b/anndata/readwrite/zarr.py
@@ -93,7 +93,8 @@ def write_series(g, k, s, dataset_kwargs={}):
             object_codec=numcodecs.VLenUTF8(),
             **dataset_kwargs,
         )
-        g[k][:] = s.values
+
+        g[k][:] = s.values.astype(str)
     elif is_categorical_dtype(s):
         g.create_dataset(k, shape=s.shape, dtype=s.cat.codes.dtype)
         g[k][:] = s.cat.codes
@@ -192,43 +193,43 @@ ZARR_WRITE_REGISTRY = {
 }
 
 
-def read_zarr(store: Union[str, Path, MutableMapping, zarr.Group]) -> AnnData:
-    """Read from a hierarchical Zarr array store.
-
-    Parameters
-    ----------
-    store
-        The filename, a :class:`~typing.MutableMapping`, or a Zarr storage class.
-    """
-    if isinstance(store, Path):
-        store = str(store)
-
-    f = zarr.open(store, mode="r")
-    d = {}
-    for k in f.keys():
-        # Backwards compat
-        if k.startswith("raw."):
-            continue
-        if k in {"obs", "var"}:
-            d[k] = read_dataframe(f[k])
-        else:  # Base case
-            d[k] = read_attribute(f[k])
-
-    # Backwards compat
-    raw = {}
-    if "raw.var" in f:
-        raw["var"] = read_dataframe(f["raw.var"])  # Backwards compat
-    if "raw.varm" in f:
-        raw["varm"] = read_attribute(f["raw.varm"])
-    if "raw.X" in f:
-        raw["X"] = read_attribute(f["raw.X"])
-    if len(raw) > 0:
-        assert "raw" not in d
-        d["raw"] = raw
-
-    _clean_uns(d)
-
-    return AnnData(**d)
+# def read_zarr(store: Union[str, Path, MutableMapping, zarr.Group]) -> AnnData:
+#     """Read from a hierarchical Zarr array store.
+#
+#     Parameters
+#     ----------
+#     store
+#         The filename, a :class:`~typing.MutableMapping`, or a Zarr storage class.
+#     """
+#     if isinstance(store, Path):
+#         store = str(store)
+#
+#     f = zarr.open(store, mode="r")
+#     d = {}
+#     for k in f.keys():
+#         # Backwards compat
+#         if k.startswith("raw."):
+#             continue
+#         if k in {"obs", "var"}:
+#             d[k] = read_dataframe(f[k])
+#         else:  # Base case
+#             d[k] = read_attribute(f[k])
+#
+#     # Backwards compat
+#     raw = {}
+#     if "raw.var" in f:
+#         raw["var"] = read_dataframe(f["raw.var"])  # Backwards compat
+#     if "raw.varm" in f:
+#         raw["varm"] = read_attribute(f["raw.varm"])
+#     if "raw.X" in f:
+#         raw["X"] = read_attribute(f["raw.X"])
+#     if len(raw) > 0:
+#         assert "raw" not in d
+#         d["raw"] = raw
+#
+#     _clean_uns(d)
+#
+#     return AnnData(**d)
 
 
 @singledispatch

--- a/anndata/zarr/__init__.py
+++ b/anndata/zarr/__init__.py
@@ -21,11 +21,8 @@ For examples and further information, see this `blog post <https://falexwolf.de/
    Dataset
    SparseDataset
 """
-from h5py import Dataset, special_dtype
+from .zarrsparse import File, Group, SparseDataset, Dataset
+from .zarrreader import Reader, read_zarr
 
-from .h5sparse import Group, File, SparseDataset
-
-from .h5reader import read_h5ad
 # Problem: the H5py intersphinx is broken, and only contains e.g. `Dataset` directly.
 # So we can’t possibly link to it using :class:`Dataset`, since that will always find our version.
-Dataset.__doc__ = """Equivalent to :class:`h5py.Dataset <h5py:Dataset>`."""

--- a/anndata/zarr/zarrreader.py
+++ b/anndata/zarr/zarrreader.py
@@ -1,0 +1,63 @@
+import numpy as np
+import scipy.sparse as sparse
+
+import anndata.mapping as adm
+import anndata.zarr as azarr
+from anndata.compat import _from_fixed_length_strings
+
+
+def read_zarr(filename, backed=None, chunk_size=None):
+    return Reader().read(filename, backed=backed)
+
+
+class Reader(adm.MappingReader):
+
+    def __init__(self):
+        super().__init__(azarr.Dataset)
+
+    def read_csr(self, group: 'zarr.Group') -> sparse.csr_matrix:
+        return sparse.csr_matrix(
+            (group["data"], group["indices"], group["indptr"]),
+            shape=group.attrs["shape"],
+        )
+
+    def read_group(self, group):
+        if "encoding-type" in group.attrs:
+            enctype = group.attrs["encoding-type"]
+            if enctype == "dataframe":
+                return self.read_dataframe(group)
+            elif enctype == "csr_matrix":
+                return self.read_csr(group)
+            elif enctype == "csc_matrix":
+                return self.read_csc(group)
+
+        return {k: self.read_attribute(group[k]) for k in group.keys()}
+
+    def read_csc(self, group: 'zarr.Group') -> sparse.csc_matrix:
+        return sparse.csc_matrix(
+            (group["data"], group["indices"], group["indptr"]),
+            shape=group.attrs["shape"],
+        )
+
+    def read_dataset(self, dataset):
+        value = dataset[...]
+        if not hasattr(value, "dtype"):
+            return value
+        elif isinstance(value.dtype, str):
+            pass
+        elif issubclass(value.dtype.type, np.str_):
+            value = value.astype(object)
+        elif issubclass(value.dtype.type, np.string_):
+            value = value.astype(str).astype(object)  # bytestring -> unicode -> str
+        elif len(value.dtype.descr) > 1:  # Compound dtype
+            # For backwards compat, now strings are written as variable length
+            value = _from_fixed_length_strings(value)
+        if value.shape == ():
+            value = value[()]
+        return value
+
+    def create_file(self, filename, mode):
+        return azarr.File(filename, mode=mode)
+
+    def close_file(self, f):
+        pass

--- a/anndata/zarr/zarrreader.py
+++ b/anndata/zarr/zarrreader.py
@@ -1,9 +1,10 @@
 import numpy as np
 import scipy.sparse as sparse
 
-import anndata.mapping as adm
-import anndata.zarr as azarr
-from anndata.compat import _from_fixed_length_strings
+
+from .. import mapping as adm
+from .zarrsparse import Dataset, File
+from ..compat import _from_fixed_length_strings
 
 
 def read_zarr(filename, backed=None, chunk_size=None):
@@ -11,9 +12,8 @@ def read_zarr(filename, backed=None, chunk_size=None):
 
 
 class Reader(adm.MappingReader):
-
     def __init__(self):
-        super().__init__(azarr.Dataset)
+        super().__init__(Dataset)
 
     def read_csr(self, group: 'zarr.Group') -> sparse.csr_matrix:
         return sparse.csr_matrix(
@@ -48,7 +48,9 @@ class Reader(adm.MappingReader):
         elif issubclass(value.dtype.type, np.str_):
             value = value.astype(object)
         elif issubclass(value.dtype.type, np.string_):
-            value = value.astype(str).astype(object)  # bytestring -> unicode -> str
+            value = value.astype(str).astype(
+                object
+            )  # bytestring -> unicode -> str
         elif len(value.dtype.descr) > 1:  # Compound dtype
             # For backwards compat, now strings are written as variable length
             value = _from_fixed_length_strings(value)
@@ -57,7 +59,7 @@ class Reader(adm.MappingReader):
         return value
 
     def create_file(self, filename, mode):
-        return azarr.File(filename, mode=mode)
+        return File(filename, mode=mode)
 
     def close_file(self, f):
         pass

--- a/anndata/zarr/zarrsparse.py
+++ b/anndata/zarr/zarrsparse.py
@@ -1,0 +1,66 @@
+from os import PathLike
+from typing import Optional
+
+import zarr
+
+import anndata.mapping as adm
+
+
+Dataset = zarr.core.Array
+
+
+class Group(adm.Group):
+
+    def __init__(self, group, force_dense=False):
+        super().__init__(group, force_dense)
+
+
+class SparseDataset(adm.SparseDataset):
+
+    def __init__(self, group):
+        super().__init__(group)
+
+    @property
+    def value(self):
+        format_class = adm.get_memory_class(self.format_str, self.__class__.FORMATS)
+        g = self.group
+        data_array = format_class(self.shape, dtype=self.dtype)
+        data_array.data = g['data'][()]
+        data_array.indices = g['indices'][()]
+        data_array.indptr = g['indptr'][()]
+        return data_array
+
+
+class File(Group):
+
+    def __init__(
+            self,
+            name: PathLike,
+            mode: Optional[str] = None,
+            force_dense: bool = False,
+            **kwds,
+    ):
+        self.root = zarr.open(
+            str(name),
+            mode=mode
+        )
+        self.fake_id = 1
+        super().__init__(self.root, force_dense)
+
+    def __enter__(self):
+        return self
+
+    def close(self):
+        self.fake_id = None
+
+    @property
+    def id(self):
+        return self.fake_id
+
+    @property
+    def filename(self):
+        return self.root.store.path
+
+
+adm.add_mapping_impl(zarr.core.Array, zarr.hierarchy.Group, 'encoding-type', 'shape', Group, SparseDataset, [File,
+                                                                                                             Dataset])

--- a/anndata/zarr/zarrsparse.py
+++ b/anndata/zarr/zarrsparse.py
@@ -2,27 +2,26 @@ from os import PathLike
 from typing import Optional
 
 import zarr
-
-import anndata.mapping as adm
+from .. import mapping as adm
 
 
 Dataset = zarr.core.Array
 
 
 class Group(adm.Group):
-
     def __init__(self, group, force_dense=False):
         super().__init__(group, force_dense)
 
 
 class SparseDataset(adm.SparseDataset):
-
     def __init__(self, group):
         super().__init__(group)
 
     @property
     def value(self):
-        format_class = adm.get_memory_class(self.format_str, self.__class__.FORMATS)
+        format_class = adm.get_memory_class(
+            self.format_str, self.__class__.FORMATS
+        )
         g = self.group
         data_array = format_class(self.shape, dtype=self.dtype)
         data_array.data = g['data'][()]
@@ -32,18 +31,14 @@ class SparseDataset(adm.SparseDataset):
 
 
 class File(Group):
-
     def __init__(
-            self,
-            name: PathLike,
-            mode: Optional[str] = None,
-            force_dense: bool = False,
-            **kwds,
+        self,
+        name: PathLike,
+        mode: Optional[str] = None,
+        force_dense: bool = False,
+        **kwds,
     ):
-        self.root = zarr.open(
-            str(name),
-            mode=mode
-        )
+        self.root = zarr.open(str(name), mode=mode)
         self.fake_id = 1
         super().__init__(self.root, force_dense)
 
@@ -62,5 +57,12 @@ class File(Group):
         return self.root.store.path
 
 
-adm.add_mapping_impl(zarr.core.Array, zarr.hierarchy.Group, 'encoding-type', 'shape', Group, SparseDataset, [File,
-                                                                                                             Dataset])
+adm.add_mapping_impl(
+    zarr.core.Array,
+    zarr.hierarchy.Group,
+    'encoding-type',
+    'shape',
+    Group,
+    SparseDataset,
+    [File, Dataset],
+)


### PR DESCRIPTION
This commit unifies the zarr and h5ad backends for reading. It supports reading zarr files in backed mode by doing a few instanceof checks that need to be fixed.

Remaining to dos:
Unify backends for writing
Update AnnDataFileManager to work with zarr files and other future formats that support the mapping interface.