### PR TITLE
Improve alignedmapping typing

### DIFF
--- a/anndata/core/alignedmapping.py
+++ b/anndata/core/alignedmapping.py
@@ -5,6 +5,7 @@ from typing import (
     Mapping,
     Optional,
     Tuple,
+    Type,
     Iterable,
     Sequence,
     Union,
@@ -22,11 +23,12 @@ from ..utils import deprecated
 from .views import asview, ViewArgs
 
 
-OneDIdx = Sequence[Union[int, bool]]
+OneDIdx = Union[Sequence[int], Sequence[bool]]
 TwoDIdx = Tuple[OneDIdx, OneDIdx]
 
-I = TypeVar("I", OneDIdx, TwoDIdx)
-V = TypeVar("V", pd.DataFrame, spmatrix, np.ndarray)
+I = TypeVar("I", OneDIdx, TwoDIdx, covariant=True)
+# TODO: pd.DataFrame only allowed in AxisArrays?
+V = Union(pd.DataFrame, spmatrix, np.ndarray)
 
 
 @singledispatch
@@ -44,19 +46,11 @@ def _subset_df(df: pd.DataFrame, subset_idx: OneDIdx):
 
 
 class AlignedMapping(cabc.MutableMapping, ABC):
-    """
-    Attributes
-    ----------
-    axes
-        Which axes is this aligned along?
-    _view_class
-        The view class for this aligned mapping.
-    _actual_class
-        The actual class (which has it's own data) for this aligned mapping.
-    """
+    _view_class: ClassVar[Type["AlignedViewMixin"]]
+    """The view class for this aligned mapping."""
 
-    _view_class: ClassVar["AlignedViewMixin"]
-    _actual_class: ClassVar["AlignedActualMixin"]
+    _actual_class: ClassVar[Type["AlignedActualMixin"]]
+    """The actual class (which has it's own data) for this aligned mapping."""
 
     def __repr__(self):
         return f"{self.__class__.__name__,} with keys: {self.keys()}"

--- a/anndata/core/alignedmapping.py
+++ b/anndata/core/alignedmapping.py
@@ -1,4 +1,3 @@
-from warnings import warn
 from abc import ABC, abstractmethod
 from collections import abc as cabc
 from functools import singledispatch

--- a/anndata/core/alignedmapping.py
+++ b/anndata/core/alignedmapping.py
@@ -76,8 +76,9 @@ class AlignedMapping(cabc.MutableMapping, ABC):
             was_heterogeneous = val.dtypes.nunique() != 1
             val = val.to_numpy()
             if was_heterogeneous:
+                name = self.attrname.title().rstrip('s')
                 warn(
-                    f'Layer {key!r} converted to numpy array '
+                    f'{name} {key!r} converted to numpy array '
                     f'with dtype {val.dtype}'
                 )
         return val
@@ -230,7 +231,7 @@ class AxisArraysBase(AlignedMapping):
             raise ValueError(
                 f"value.index does not match parent’s axis {self.axes[0]} names"
             )
-        return super()._validate_value(self, val, key)
+        return super()._validate_value(val, key)
 
 
 class AxisArrays(AlignedActualMixin, AxisArraysBase):

--- a/anndata/core/alignedmapping.py
+++ b/anndata/core/alignedmapping.py
@@ -28,7 +28,7 @@ TwoDIdx = Tuple[OneDIdx, OneDIdx]
 
 I = TypeVar("I", OneDIdx, TwoDIdx, covariant=True)
 # TODO: pd.DataFrame only allowed in AxisArrays?
-V = Union(pd.DataFrame, spmatrix, np.ndarray)
+V = Union[pd.DataFrame, spmatrix, np.ndarray]
 
 
 @singledispatch

--- a/anndata/core/alignedmapping.py
+++ b/anndata/core/alignedmapping.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import spmatrix
 
-from ..utils import deprecated
+from ..utils import deprecated, ensure_df_homogeneous
 from .views import asview, ViewArgs
 
 if TYPE_CHECKING:
@@ -73,14 +73,8 @@ class AlignedMapping(cabc.MutableMapping, ABC):
                     f"it should have had {right_shape}."
                 )
         if not self._allow_df and isinstance(val, pd.DataFrame):
-            was_heterogeneous = val.dtypes.nunique() != 1
-            val = val.to_numpy()
-            if was_heterogeneous:
-                name = self.attrname.title().rstrip('s')
-                warn(
-                    f'{name} {key!r} converted to numpy array '
-                    f'with dtype {val.dtype}'
-                )
+            name = self.attrname.title().rstrip('s')
+            val = ensure_df_homogeneous(val, f'{name} {key!r}')
         return val
 
     @property

--- a/anndata/core/alignedmapping.py
+++ b/anndata/core/alignedmapping.py
@@ -23,7 +23,7 @@ from ..utils import deprecated
 from .views import asview, ViewArgs
 
 
-OneDIdx = Union[Sequence[int], Sequence[bool]]
+OneDIdx = Union[Sequence[int], Sequence[bool], slice]
 TwoDIdx = Tuple[OneDIdx, OneDIdx]
 
 I = TypeVar("I", OneDIdx, TwoDIdx, covariant=True)

--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -1029,17 +1029,19 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         return self._raw
 
     @raw.setter
-    def raw(self, value: Optional['AnnData']):
-        if value is None:
-            self._raw = None
-        elif isinstance(value, AnnData):
-            if self.isview:
-                self._init_as_actual(self.copy())
-            self._raw = Raw(value)
-        else:
+    def raw(self, value: 'AnnData'):
+        if not isinstance(value, AnnData):
             raise ValueError(
-                'Can only init raw attribute with an AnnData object or `None`.'
+                'Can only init raw attribute with an AnnData object. '
+                'Do `del adata.raw` to delete it'
             )
+        if self.isview:
+            self._init_as_actual(self.copy())
+        self._raw = Raw(value)
+
+    @raw.deleter
+    def raw(self):
+        self._raw = None
 
     @property
     def n_obs(self) -> int:

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -46,7 +46,7 @@ def gen_typed_df(n, index=None):
     )
 
 
-def gen_typed_df_t2_size(m, n, index=None, columns=None):
+def gen_typed_df_t2_size(m, n, index=None, columns=None) -> pd.DataFrame:
     s = 0
     df = pd.DataFrame()
     new_vals = gen_typed_df(m)
@@ -128,9 +128,7 @@ def gen_adata(
     )
     varm = {k: v for k, v in varm.items() if type(v) in varm_types}
     layers = dict(
-        array=np.random.random((M, N)),
-        sparse=sparse.random(M, N, format="csr"),
-        df=gen_typed_df_t2_size(M, N, index=obs_names, columns=var_names),
+        array=np.random.random((M, N)), sparse=sparse.random(M, N, format="csr")
     )
     layers = {k: v for k, v in layers.items() if type(v) in layers_types}
     obsp = dict(
@@ -357,9 +355,8 @@ def assert_adata_equal(a: AnnData, b: AnnData, exact: bool = False):
     if not exact:
         # Reorder all elements if neccesary
         idx = [slice(None), slice(None)]
-        change_flag = (
-            False
-        )  # Since it's a pain to compare a list of pandas objects
+        # Since it's a pain to compare a list of pandas objects
+        change_flag = False
         if not np.all(a.obs_names == b.obs_names):
             idx[0] = a.obs_names
             change_flag = True

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -93,8 +93,7 @@ def test_create_from_df_with_obs_and_var():
 
 def test_df_warnings():
     df = pd.DataFrame(
-        dict(A=[1, 2, 3], B=[1., 2., 3.]),
-        index=['a', 'b', 'c'],
+        dict(A=[1, 2, 3], B=[1.0, 2.0, 3.0]), index=['a', 'b', 'c']
     )
     with pytest.warns(UserWarning, match=r"X.*dtype float64"):
         adata = AnnData(df)

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -36,9 +36,7 @@ def test_creation():
     assert adata.raw.X.tolist() == X.tolist()
     assert adata.raw.var_names.tolist() == ['a', 'b', 'c']
 
-    from pytest import raises
-
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         AnnData(np.array([[1, 2], [3, 4]]), dict(TooLong=[1, 2, 3, 4]))
 
     # init with empty data matrix
@@ -83,12 +81,25 @@ def test_create_from_df_with_obs_and_var():
     assert obs.equals(ad.obs)
     assert var.equals(ad.var)
 
-    from pytest import raises
-
-    with raises(ValueError, match=r'Index of obs must match index of X.'):
+    with pytest.raises(
+        ValueError, match=r'Index of obs must match index of X.'
+    ):
         AnnData(df, obs=obs.reset_index())
-    with raises(ValueError, match=r'Index of var must match columns of X.'):
+    with pytest.raises(
+        ValueError, match=r'Index of var must match columns of X.'
+    ):
         AnnData(df, var=var.reset_index())
+
+
+def test_df_warnings():
+    df = pd.DataFrame(
+        dict(A=[1, 2, 3], B=[1., 2., 3.]),
+        index=['a', 'b', 'c'],
+    )
+    with pytest.warns(UserWarning, match=r"X.*dtype float64"):
+        adata = AnnData(df)
+    with pytest.warns(UserWarning, match=r"X.*dtype float64"):
+        adata.X = df
 
 
 def test_names():
@@ -215,21 +226,19 @@ def test_slicing_strings():
     assert adata[:, np.array(['a', 'c'])].X.tolist() == [[1, 3], [4, 6]]
     assert adata[:, 'b':'c'].X.tolist() == [[2, 3], [5, 6]]
 
-    from pytest import raises
-
-    with raises(KeyError):
+    with pytest.raises(KeyError):
         _ = adata[:, 'X']
-    with raises(KeyError):
+    with pytest.raises(KeyError):
         _ = adata['X', :]
-    with raises(KeyError):
+    with pytest.raises(KeyError):
         _ = adata['A':'X', :]
-    with raises(KeyError):
+    with pytest.raises(KeyError):
         _ = adata[:, 'a':'X']
 
     # Test if errors are helpful
-    with raises(KeyError, match=r"not_in_var"):
+    with pytest.raises(KeyError, match=r"not_in_var"):
         adata[:, ["A", "B", "not_in_var"]]
-    with raises(KeyError, match=r"not_in_obs"):
+    with pytest.raises(KeyError, match=r"not_in_obs"):
         adata[["A", "B", "not_in_obs"], :]
 
 
@@ -319,9 +328,7 @@ def test_append_col():
     # this worked in the initial AnnData, but not with a dataframe
     # adata.obs[['new2', 'new3']] = [['A', 'B'], ['c', 'd']]
 
-    from pytest import raises
-
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         adata.obs['new4'] = 'far too long'.split()
 
 
@@ -342,9 +349,7 @@ def test_set_obs():
     adata.obs = pd.DataFrame(dict(a=[3, 4]))
     assert adata.obs_names.tolist() == [0, 1]
 
-    from pytest import raises
-
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         adata.obs = pd.DataFrame(dict(a=[3, 4, 5]))
         adata.obs = dict(a=[1, 2])
 

--- a/anndata/tests/test_layers.py
+++ b/anndata/tests/test_layers.py
@@ -1,17 +1,17 @@
 from importlib.util import find_spec
-from pathlib import Path
 
 import pytest
 import numpy as np
-import anndata as ad
 
+from anndata import AnnData, read_loom, read_h5ad
+from anndata.tests.helpers import gen_typed_df_t2_size
 
 X = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 L = np.array([[10, 11, 12], [13, 14, 15], [16, 17, 18]])
 
 
 def test_creation():
-    adata = ad.AnnData(X=X, layers={'L': L.copy()})
+    adata = AnnData(X=X, layers=dict(L=L.copy()))
 
     assert list(adata.layers.keys()) == ['L']
     assert "L" in adata.layers
@@ -21,7 +21,7 @@ def test_creation():
 
 
 def test_views():
-    adata = ad.AnnData(X=X, layers={'L': L.copy()})
+    adata = AnnData(X=X, layers=dict(L=L.copy()))
     adata_view = adata[1:, 1:]
 
     assert adata_view.layers.isview
@@ -41,10 +41,19 @@ def test_views():
     assert not adata_view.isview
 
 
+def test_set_dataframe():
+    adata = AnnData(X)
+    df = gen_typed_df_t2_size(*X.shape)
+    with pytest.warns(UserWarning, match=r"Layer 'df'.*dtype object"):
+        adata.layers["df"] = df
+    assert isinstance(adata.layers["df"], np.ndarray)
+    assert np.issubdtype(adata.layers["df"].dtype, object)
+
+
 def test_readwrite(backing_h5ad):
-    adata = ad.AnnData(X=X, layers={'L': L.copy()})
+    adata = AnnData(X=X, layers=dict(L=L.copy()))
     adata.write(backing_h5ad)
-    adata_read = ad.read_h5ad(backing_h5ad)
+    adata_read = read_h5ad(backing_h5ad)
 
     assert adata.layers.keys() == adata_read.layers.keys()
     assert (adata.layers['L'] == adata_read.layers['L']).all()
@@ -52,10 +61,10 @@ def test_readwrite(backing_h5ad):
 
 @pytest.mark.skipif(find_spec('loompy') is None, reason="loompy not installed")
 def test_readwrite_loom(tmp_path):
-    loom_path = Path(tmp_path / 'test.loom')
-    adata = ad.AnnData(X=X, layers={'L': L.copy()})
+    loom_path = tmp_path / 'test.loom'
+    adata = AnnData(X=X, layers=dict(L=L.copy()))
     adata.write_loom(loom_path)
-    adata_read = ad.read_loom(loom_path, X_name='')
+    adata_read = read_loom(loom_path, X_name='')
 
     assert adata.layers.keys() == adata_read.layers.keys()
     assert (adata.layers['L'] == adata_read.layers['L']).all()
@@ -67,7 +76,7 @@ def test_backed():
 
 
 def test_copy():
-    adata = ad.AnnData(X=X, layers={'L': L.copy()})
+    adata = AnnData(X=X, layers=dict(L=L.copy()))
     bdata = adata.copy()
     adata.layers['L'] += 10
     assert np.all(adata.layers['L'] != bdata.layers['L'])  # 201

--- a/anndata/tests/test_obsmvarm.py
+++ b/anndata/tests/test_obsmvarm.py
@@ -63,10 +63,10 @@ def test_setting_ndarray(adata):
 
 def test_setting_dataframe(adata):
     obsm_df = pd.DataFrame(
-        dict(b_1=np.ones(M), b_2=["a" for i in range(M)]), index=adata.obs_names
+        dict(b_1=np.ones(M), b_2=["a"] * M), index=adata.obs_names
     )
     varm_df = pd.DataFrame(
-        dict(b_1=np.ones(N), b_2=["a" for i in range(N)]), index=adata.var_names
+        dict(b_1=np.ones(N), b_2=["a"] * N), index=adata.var_names
     )
 
     adata.obsm["b"] = obsm_df
@@ -76,12 +76,12 @@ def test_setting_dataframe(adata):
 
     bad_obsm_df = obsm_df.copy()
     bad_obsm_df.reset_index(inplace=True)
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError):
         adata.obsm["c"] = bad_obsm_df
 
     bad_varm_df = varm_df.copy()
     bad_varm_df.reset_index(inplace=True)
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError):
         adata.varm["c"] = bad_varm_df
 
 

--- a/anndata/tests/test_obspvarp.py
+++ b/anndata/tests/test_obspvarp.py
@@ -96,7 +96,9 @@ def test_setting_sparse(adata):
 )
 def test_setting_dataframe(adata, field, dim, homogenous, df, dtype):
     if homogenous:
-        with pytest.warns(UserWarning, match=rf"{dim.title()} 'df'.*dtype object"):
+        with pytest.warns(
+            UserWarning, match=rf"{field.title()} 'df'.*dtype object"
+        ):
             getattr(adata, field)["df"] = df(dim)
     else:
         with pytest.warns(None) as warnings:

--- a/anndata/tests/test_obspvarp.py
+++ b/anndata/tests/test_obspvarp.py
@@ -96,7 +96,7 @@ def test_setting_sparse(adata):
 )
 def test_setting_dataframe(adata, field, dim, homogenous, df, dtype):
     if homogenous:
-        with pytest.warns(UserWarning, match=r"Layer 'df'.*dtype object"):
+        with pytest.warns(UserWarning, match=rf"{dim.title()} 'df'.*dtype object"):
             getattr(adata, field)["df"] = df(dim)
     else:
         with pytest.warns(None) as warnings:

--- a/anndata/tests/test_raw.py
+++ b/anndata/tests/test_raw.py
@@ -63,3 +63,6 @@ def test_raw(backing_h5ad):
     assert adata.raw[:, 0].X.tolist() == [[1], [4], [7]]
     assert adata.raw.var_names.tolist() == ['var1', 'var2', 'var3']
     assert adata.var_names.tolist() == ['var1', 'var2']
+
+    del adata.raw
+    assert adata.raw is None

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -204,8 +204,6 @@ def test_maintain_layers(backing_h5ad):
     assert not np.any(
         (orig.layers["sparse"] != curr.layers["sparse"]).toarray()
     )
-    assert type(orig.layers["df"]) is type(curr.layers["df"])
-    assert np.all(orig.layers["df"] == curr.layers["df"])
 
 
 @pytest.mark.xfail

--- a/anndata/utils.py
+++ b/anndata/utils.py
@@ -89,6 +89,13 @@ def warn_no_string_index(names: Sequence[Any]):
         )
 
 
+def ensure_df_homogeneous(df: pd.DataFrame, name: str) -> np.ndarray:
+    arr = df.to_numpy()
+    if df.dtypes.nunique() != 1:
+        warnings.warn(f'{name} converted to numpy array with dtype {arr.dtype}')
+    return arr
+
+
 def convert_dictionary_to_structured_array(source: Mapping[str, Sequence[Any]]):
     names = list(source.keys())
     try:  # transform to byte-strings


### PR DESCRIPTION
See 62c488658fe7f3a3898d35c576ce308e69e78de8

Let’s continue discussion here. I seem to misunderstand a few things about the new `AlignedMapping`s:

- I thought `obsm` and `varm` (`AxisArrays`) are the only ones where heterogenous `pd.DataFrame`s can be put in?
- I thought `layers` (`Layers`) is the onle one that is aligned to both axes instead of just one?
- I thought all of those are indexed only with `str`s? I mean technically there’s no need to, any hashable should work…