### PR TITLE
alignedmapping repr & delete methods for anndata attrs

### DIFF
--- a/anndata/core/alignedmapping.py
+++ b/anndata/core/alignedmapping.py
@@ -55,7 +55,7 @@ class AlignedMapping(cabc.MutableMapping, ABC):
     """The actual class (which has it's own data) for this aligned mapping."""
 
     def __repr__(self):
-        return f"{type(self).__name__} with keys: {self.keys()}"
+        return f"{type(self).__name__} with keys: {', '.join(self.keys())}"
 
     def _ipython_key_completions_(self) -> List[Hashable]:
         return list(self.keys())

--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -1036,6 +1036,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             self._init_as_actual(self.copy())
         self._layers = layers
 
+    @layers.deleter
+    def layers(self):
+        self.layers = dict()
+
     @property
     def raw(self) -> Raw:
         """\
@@ -1075,6 +1079,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
     @raw.deleter
     def raw(self):
+        if self.isview:
+            self._init_as_actual(self.copy())
         self._raw = None
 
     @property
@@ -1103,6 +1109,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             self._init_as_actual(self.copy())
         self._obs = value
 
+    @obs.deleter
+    def obs(self):
+        self.obs = pd.DataFrame(index=self.obs_names)
+
     @property
     def var(self) -> pd.DataFrame:
         """\
@@ -1121,6 +1131,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             self._init_as_actual(self.copy())
         self._var = value
 
+    @var.deleter
+    def var(self):
+        self.var = pd.DataFrame(index=self.var_names)
+
     @property
     def uns(self) -> MutableMapping:
         """Unstructured annotation (ordered dictionary)."""
@@ -1135,6 +1149,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         if self.isview:
             self._init_as_actual(self.copy())
         self._uns = value
+
+    @uns.deleter
+    def uns(self):
+        self.uns = OrderedDict()
 
     @property
     def obsm(self) -> Union[AxisArrays, AxisArraysView]:
@@ -1156,6 +1174,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             self._init_as_actual(self.copy())
         self._obsm = obsm
 
+    @obsm.deleter
+    def obsm(self):
+        self.obsm = dict()
+
     @property
     def varm(self) -> Union[AxisArrays, AxisArraysView]:
         """\
@@ -1175,6 +1197,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         if self.isview:
             self._init_as_actual(self.copy())
         self._varm = varm
+
+    @varm.deleter
+    def varm(self):
+        self.varm = dict()
 
     @property
     def obsp(self) -> Union[PairwiseArrays, PairwiseArraysView]:
@@ -1196,6 +1222,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             self._init_as_actual(self.copy())
         self._obsp = obsp
 
+    @obsp.deleter
+    def obsp(self):
+        self.obsp = dict()
+
     @property
     def varp(self) -> Union[PairwiseArrays, PairwiseArraysView]:
         """\
@@ -1215,6 +1245,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         if self.isview:
             self._init_as_actual(self.copy())
         self._varp = varp
+
+    @varp.deleter
+    def varp(self):
+        self.varp = dict()
 
     @property
     def obs_names(self) -> pd.Index:

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -8,6 +8,7 @@ from scipy import sparse as sp
 from scipy.sparse import csr_matrix, isspmatrix_csr
 
 from anndata import AnnData
+from helpers import assert_equal, gen_adata
 
 
 # some test objects that we use below
@@ -99,6 +100,16 @@ def test_df_warnings():
         adata = AnnData(df)
     with pytest.warns(UserWarning, match=r"X.*dtype float64"):
         adata.X = df
+
+
+def test_attr_deletion():
+    full = gen_adata((30, 30))
+    # Empty has just X, obs_names, var_names
+    empty = AnnData(full.X, obs=full.obs[[]], var=full.var[[]])
+    for attr in ["obs", "var", "obsm", "varm", "obsp", "varp", "layers"]:
+        delattr(full, attr)
+        assert_equal(getattr(full, attr), getattr(empty, attr))
+    assert_equal(full, empty, exact=True)
 
 
 def test_names():

--- a/anndata/tests/test_repr.py
+++ b/anndata/tests/test_repr.py
@@ -1,0 +1,62 @@
+import re
+from string import ascii_letters
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import anndata as ad
+
+ADATA_ATTRS = ("obs", "var", "varm", "obsm", "layers", "obsp", "varp", "uns")
+
+
+@pytest.fixture
+def adata():
+    return ad.AnnData(
+        np.zeros((20, 10)),
+        obs=pd.DataFrame(
+            {"obs_key": list(ascii_letters[:20])},
+            index=[f"cell{i}" for i in range(20)],
+        ),
+        var=pd.DataFrame(
+            {"var_key": np.arange(10)}, index=[f"gene{i}" for i in range(10)]
+        ),
+        varm={"varm_key": np.zeros((10, 20))},
+        obsm={"obsm_key": np.zeros((20, 20))},
+        layers={"layers_key": np.zeros((20, 10))},
+        obsp={"obsp_key": np.zeros((20, 20))},
+        varp={"varp_key": np.zeros((10, 10))},
+        uns={"uns_key": dict(zip("abc", range(3)))},
+    )
+
+
+@pytest.fixture(params=ADATA_ATTRS)
+def adata_attr(request):
+    return request.param
+
+
+def test_anndata_repr(adata):
+    assert f"{adata.n_obs} × {adata.n_vars}" in repr(adata)
+
+    for idxr in [
+        (slice(10, 20), 12),
+        (12, 10),
+        (["cell1", "cell2"], slice(10, 15)),
+    ]:
+        v = adata[idxr]
+        v_repr = repr(v)
+        assert f"{v.n_obs} × {v.n_vars}" in v_repr
+        assert "View of" in v_repr
+        for attr in ADATA_ATTRS:
+            assert re.search(
+                rf"^\s+{attr}:[^$]*{attr}_key.*$", v_repr, flags=re.MULTILINE
+            )
+
+
+def test_removal(adata, adata_attr):
+    attr = adata_attr
+    assert re.search(rf"^\s+{attr}:.*$", repr(adata), flags=re.MULTILINE)
+    delattr(adata, attr)
+    assert (
+        re.search(rf"^\s+{attr}:.*$", repr(adata), flags=re.MULTILINE) is None
+    )

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -338,6 +338,20 @@ def test_view_delitem(attr):
     assert view_hash != joblib.hash(view)
 
 
+@pytest.mark.parametrize(
+    'attr', ["obs", "var", "obsm", "varm", "obsp", "varp", "layers"]
+)
+def test_view_delattr(attr):
+    base = gen_adata((10, 10))
+    # Indexing into obs and var just to get indexes
+    subset = base[5:7, :5]
+    empty = ad.AnnData(subset.X, obs=subset.obs[[]], var=subset.var[[]])
+    delattr(subset, attr)
+    assert not subset.isview
+    # Should now have same value as default
+    assert_equal(getattr(subset, attr), getattr(empty, attr))
+
+
 def test_layers_view():
     X = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     L = np.array([[10, 11, 12], [13, 14, 15], [16, 17, 18]])


### PR DESCRIPTION
Previously, the aligned mapping repr would throw an error if called since it starting a recursion loop. This has been fixed and tested. To make sure reprs worked, I added some tests, but found out it'd be easier to do this if I could remove attributes. This led me to implement deleter methods for the main attributes (except `raw`).

Now you can do:

```python
>>> adata.layers
Layers with keys: counts, log_norm

>>> del adata.layers

>>> adata.layers
Layers with keys:
```