### PR TITLE
Fix structured array IO

### DIFF
--- a/anndata/compat.py
+++ b/anndata/compat.py
@@ -75,7 +75,7 @@ def _from_fixed_length_strings(value):
         # https://github.com/h5py/h5py/issues/1307
         if issubclass(np.dtype(dt_type).type, np.string_):
             dt_list[1] = f"U{int(dt_type[2:])}"
-        elif is_annotated or issubclass(np.dtype(dt_type).type, np.str_):
+        elif is_annotated or np.issubdtype(np.dtype(dt_type), np.str_):
             dt_list[1] = "O"  # Assumption that it's a vlen str
         new_dtype.append(tuple(dt_list))
     return value.astype(new_dtype)
@@ -91,9 +91,9 @@ def _to_fixed_length_strings(value: np.ndarray) -> np.ndarray:
     new_dtype = []
     for dt_name, (dt_type, dt_offset) in value.dtype.fields.items():
         if dt_type.kind == "O":
-            #  Asumming the objects are str
+            #  Assuming the objects are str
             size = max(len(x.encode()) for x in value.getfield("O", dt_offset))
-            new_dtype.append((dt_name, f"U{size}"))
+            new_dtype.append((dt_name, ("U", size)))
         else:
             new_dtype.append((dt_name, dt_type))
     return value.astype(new_dtype)

--- a/anndata/compat.py
+++ b/anndata/compat.py
@@ -89,9 +89,11 @@ def _to_fixed_length_strings(value: np.ndarray) -> np.ndarray:
     https://github.com/zarr-developers/zarr-python/pull/422
     """
     new_dtype = []
-    for dt_name, (dt_type, _) in value.dtype.fields.items():
-        if dt_type.str[1] in ("U", "O"):
-            new_dtype.append((dt_name, "U200"))
+    for dt_name, (dt_type, dt_offset) in value.dtype.fields.items():
+        if dt_type.kind == "O":
+            #  Asumming the objects are str
+            size = max(len(x.encode()) for x in value.getfield("O", dt_offset))
+            new_dtype.append((dt_name, f"U{size}"))
         else:
             new_dtype.append((dt_name, dt_type))
     return value.astype(new_dtype)

--- a/anndata/compat.py
+++ b/anndata/compat.py
@@ -75,9 +75,25 @@ def _from_fixed_length_strings(value):
         # https://github.com/h5py/h5py/issues/1307
         if issubclass(np.dtype(dt_type).type, np.string_):
             dt_list[1] = f"U{int(dt_type[2:])}"
-        elif is_annotated:
+        elif is_annotated or issubclass(np.dtype(dt_type).type, np.str_):
             dt_list[1] = "O"  # Assumption that it's a vlen str
         new_dtype.append(tuple(dt_list))
+    return value.astype(new_dtype)
+
+
+def _to_fixed_length_strings(value: np.ndarray) -> np.ndarray:
+    """
+    Convert variable length strings to fixed length.
+
+    Currently a workaround for
+    https://github.com/zarr-developers/zarr-python/pull/422
+    """
+    new_dtype = []
+    for dt_name, (dt_type, _) in value.dtype.fields.items():
+        if dt_type.str[1] in ("U", "O"):
+            new_dtype.append((dt_name, "U200"))
+        else:
+            new_dtype.append((dt_name, dt_type))
     return value.astype(new_dtype)
 
 

--- a/anndata/readwrite/h5ad.py
+++ b/anndata/readwrite/h5ad.py
@@ -34,8 +34,8 @@ def _to_hdf5_vlen_strings(value: np.ndarray) -> np.ndarray:
     This corrects compound dtypes to work with hdf5 files.
     """
     new_dtype = []
-    for dt_name, dt_type in value.dtype.descr:
-        if dt_type[1] in ("U", "O"):
+    for dt_name, (dt_type, _) in value.dtype.fields.items():
+        if dt_type.kind in ("U", "O"):
             new_dtype.append((dt_name, h5py.special_dtype(vlen=str)))
         else:
             new_dtype.append((dt_name, dt_type))

--- a/anndata/readwrite/h5ad.py
+++ b/anndata/readwrite/h5ad.py
@@ -35,7 +35,7 @@ def _to_hdf5_vlen_strings(value: np.ndarray) -> np.ndarray:
     """
     new_dtype = []
     for dt_name, dt_type in value.dtype.descr:
-        if dt_type[1] == "U":
+        if dt_type[1] in ("U", "O"):
             new_dtype.append((dt_name, h5py.special_dtype(vlen=str)))
         else:
             new_dtype.append((dt_name, dt_type))

--- a/anndata/readwrite/h5ad.py
+++ b/anndata/readwrite/h5ad.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from functools import _find_impl, singledispatch, partial
+from functools import _find_impl, partial
 from pathlib import Path
 import re
 from types import MappingProxyType

--- a/anndata/readwrite/utils.py
+++ b/anndata/readwrite/utils.py
@@ -1,5 +1,4 @@
 from functools import wraps, singledispatch
-import sys
 from ..core.sparsedataset import SparseDataset
 
 # -------------------------------------------------------------------------------
@@ -193,6 +192,6 @@ def report_write_key_on_error(func):
                 f"{e}\n\n"
                 f"Above error raised while writing key '{key}' of {type(elem)}"
                 f" from {parent}."
-            ).with_traceback(sys.exc_info()[2])
+            ) from e
 
     return func_wrapper

--- a/anndata/readwrite/utils.py
+++ b/anndata/readwrite/utils.py
@@ -112,6 +112,8 @@ def read_attribute_none(value) -> None:
 # -------------------------------------------------------------------------------
 # Errors handling
 # -------------------------------------------------------------------------------
+# TODO: Is there a consistent way to do this which just modifies the previously
+# thrown error? Could do a warning?
 
 
 class AnnDataReadError(OSError):
@@ -200,12 +202,10 @@ def report_write_key_on_error(func):
                     "\n\n".join(
                         (
                             str(e),
-                            f"Above error raised while writing key '{key}' of type {type(val)} from {parent}.",
+                            f"Above error raised while writing key '{key}' of "
+                            f"type {type(val)} from {parent}.",
                         )
                     )
-                )
-                # raise AnnDataReadError(
-                #     f"Above error raised while writing key '{key}' of type {type(val)} from {parent}."
-                # )
+                ).with_traceback(sys.exc_info()[2])
 
     return func_wrapper

--- a/anndata/readwrite/zarr.py
+++ b/anndata/readwrite/zarr.py
@@ -13,7 +13,11 @@ import numcodecs
 import zarr
 
 from ..core.anndata import AnnData, Raw
-from ..compat import _from_fixed_length_strings, _clean_uns
+from ..compat import (
+    _from_fixed_length_strings,
+    _to_fixed_length_strings,
+    _clean_uns,
+)
 from .utils import (
     report_read_key_on_error,
     report_write_key_on_error,
@@ -150,6 +154,11 @@ def write_array(g, key, value, dataset_kwargs=MappingProxyType({})):
             **dataset_kwargs,
         )
         g[key][:] = value
+    elif value.dtype.kind == "V":
+        # Structured dtype
+        g.create_dataset(
+            key, data=_to_fixed_length_strings(value), **dataset_kwargs
+        )
     else:
         g.create_dataset(key, data=value, **dataset_kwargs)
 

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -1,4 +1,4 @@
-from functools import singledispatch, partial, wraps
+from functools import singledispatch, wraps
 from string import ascii_letters
 from typing import Tuple
 from collections.abc import Mapping

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -106,7 +106,7 @@ def test_attr_deletion():
     full = gen_adata((30, 30))
     # Empty has just X, obs_names, var_names
     empty = AnnData(full.X, obs=full.obs[[]], var=full.var[[]])
-    for attr in ["obs", "var", "obsm", "varm", "obsp", "varp", "layers"]:
+    for attr in ["obs", "var", "obsm", "varm", "obsp", "varp", "layers", "uns"]:
         delattr(full, attr)
         assert_equal(getattr(full, attr), getattr(empty, attr))
     assert_equal(full, empty, exact=True)

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_categorical
 import pytest
-from scipy.sparse import csr_matrix, csc_matrix, issparse
+from scipy.sparse import csr_matrix, csc_matrix
 
 import anndata as ad
 

--- a/anndata/tests/test_utils.py
+++ b/anndata/tests/test_utils.py
@@ -2,11 +2,11 @@ import pytest
 import zarr
 import h5py
 
-from anndata.readwrite.utils import report_key_on_error, AnnDataReadError
+from anndata.readwrite.utils import report_read_key_on_error, AnnDataReadError
 
 
 def test_key_error(tmp_path):
-    @report_key_on_error
+    @report_read_key_on_error
     def read_attr(group):
         raise NotImplementedError()
 

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -1,4 +1,4 @@
-from operator import ne, mul
+from operator import mul
 
 import joblib
 import numpy as np


### PR DESCRIPTION
Fixes #249 and fixes theislab/scanpy#832 by saying we'll always read unicode strings in as variable length. This still needs an editing pass, and another look over in the morning, but I'd like to get feedback as soon as possible. @flying-sheep, thoughts?