### PR TITLE
to_adata for .raw

### DIFF
--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -369,7 +369,7 @@ class Raw:
             varm=None if self._varm is None else self._varm.copy(),
             obs=self._adata.obs.copy(),
             obsm=self._adata.obsm.copy(),
-            uns=self._adata.uns.copy()
+            uns=self._adata.uns.copy(),
         )
 
     def _normalize_indices(self, packed_index):

--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -360,6 +360,18 @@ class Raw:
             varm=None if self._varm is None else self._varm.copy(),
         )
 
+    def to_adata(self):
+        """Create full AnnData object.
+        """
+        return AnnData(
+            X=self._X.copy(),
+            var=self._var.copy(),
+            varm=None if self._varm is None else self._varm.copy(),
+            obs=self._adata.obs.copy(),
+            obsm=self._adata.obsm.copy(),
+            uns=self._adata.uns.copy()
+        )
+
     def _normalize_indices(self, packed_index):
         # deal with slicing with pd.Series
         if isinstance(packed_index, pd.Series):


### PR DESCRIPTION
Allows to replace ugly code like
```
adata_new = AnnData(adata.raw.X, var=adata.raw.var, obs=adata.obs, obsm=adata.obsm, uns=adata.uns)
```
with 
```
adata_new = adata.raw.to_adata()
```