### PR TITLE
Color handling in uns fix

### DIFF
--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -1416,16 +1416,22 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             all_categories = df_full[k].cat.categories
             df_sub[k].cat.remove_unused_categories(inplace=True)
             # also correct the colors...
-            if f'{k}_colors' not in uns:
+            color_key = f"{k}_colors"
+            if color_key not in uns:
                 continue
+            color_vec = uns[color_key]
             # this is a strange hack...
-            if np.array(uns[f'{k}_colors']).ndim == 0:
-                idx = None
+            # What case is this? Does this happen?
+            if np.array(color_vec).ndim == 0:
+                uns[color_key] = np.array(color_vec)[(None,)]
+            elif len(color_vec) < len(all_categories):
+                # Reset colors
+                del uns[color_key]
             else:
                 idx = np.where(
                     np.in1d(all_categories, df_sub[k].cat.categories)
                 )[0]
-            uns[f'{k}_colors'] = np.array(uns[f'{k}_colors'])[(idx,)]
+                uns[color_key] = np.array(color_vec)[(idx,)]
 
     def rename_categories(self, key: str, categories: Sequence[Any]):
         """\

--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -1424,7 +1424,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             # What case is this? Does this happen?
             if np.array(color_vec).ndim == 0:
                 uns[color_key] = np.array(color_vec)[(None,)]
-            elif len(color_vec) < len(all_categories):
+            elif len(color_vec) != len(all_categories):
                 # Reset colors
                 del uns[color_key]
             else:

--- a/anndata/core/anndata.py
+++ b/anndata/core/anndata.py
@@ -1420,9 +1420,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             if color_key not in uns:
                 continue
             color_vec = uns[color_key]
-            # this is a strange hack...
-            # What case is this? Does this happen?
             if np.array(color_vec).ndim == 0:
+                # Make 0D arrays into 1D ones
                 uns[color_key] = np.array(color_vec)[(None,)]
             elif len(color_vec) != len(all_categories):
                 # Reset colors

--- a/anndata/tests/test_uns.py
+++ b/anndata/tests/test_uns.py
@@ -6,17 +6,24 @@ from anndata import AnnData
 
 def test_uns_color_subset():
     # Tests for https://github.com/theislab/anndata/issues/257
-    # Tests when the length of the color vector doesn't match with the number of categories
     obs = pd.DataFrame(index=[f"cell{i}" for i in range(5)])
-    obs["cat"] = pd.Series(list("aabcd"), index=obs.index, dtype="category")
-    uns = {"cat_colors": ["red", "green", "blue"]}
+    obs["cat1"] = pd.Series(list("aabcd"), index=obs.index, dtype="category")
+    obs["cat2"] = pd.Series(list("aabbb"), index=obs.index, dtype="category")
+    uns = {
+        "cat1_colors": ["red", "green", "blue"],
+        "cat2_colors": ["red", "green", "blue"],
+    }
 
     adata = AnnData(np.ones((5, 5)), obs=obs, uns=uns)
 
+    # If number of categories does not match number of colors, they should be
+    # reset
     v = adata[:, [0, 1]]
-    assert "cat_colors" not in v.uns
+    assert "cat1_colors" not in v.uns
+    assert "cat2_colors" not in v.uns
 
-    adata.uns["cat_colors"] = ["red", "green", "blue", "yellow"]
+    # Otherwise the colors should still match after reseting
+    adata.uns["cat1_colors"] = ["red", "green", "blue", "yellow"]
     v = adata[[0, 1], :]
-    assert len(v.uns["cat_colors"]) == 1
-    assert v.uns["cat_colors"][0] == "red"
+    assert len(v.uns["cat1_colors"]) == 1
+    assert v.uns["cat1_colors"][0] == "red"

--- a/anndata/tests/test_uns.py
+++ b/anndata/tests/test_uns.py
@@ -16,8 +16,8 @@ def test_uns_color_subset():
 
     adata = AnnData(np.ones((5, 5)), obs=obs, uns=uns)
 
-    # If number of categories does not match number of colors, they should be
-    # reset
+    # If number of categories does not match number of colors,
+    # they should be reset
     v = adata[:, [0, 1]]
     assert "cat1_colors" not in v.uns
     assert "cat2_colors" not in v.uns

--- a/anndata/tests/test_uns.py
+++ b/anndata/tests/test_uns.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pandas as pd
+
+from anndata import AnnData
+
+
+def test_uns_color_subset():
+    # Tests for https://github.com/theislab/anndata/issues/257
+    # Tests when the length of the color vector doesn't match with the number of categories
+    obs = pd.DataFrame(index=[f"cell{i}" for i in range(5)])
+    obs["cat"] = pd.Series(list("aabcd"), index=obs.index, dtype="category")
+    uns = {"cat_colors": ["red", "green", "blue"]}
+
+    adata = AnnData(np.ones((5, 5)), obs=obs, uns=uns)
+
+    v = adata[:, [0, 1]]
+    assert "cat_colors" not in v.uns
+
+    adata.uns["cat_colors"] = ["red", "green", "blue", "yellow"]
+    v = adata[[0, 1], :]
+    assert len(v.uns["cat_colors"]) == 1
+    assert v.uns["cat_colors"][0] == "red"

--- a/anndata/tests/test_uns.py
+++ b/anndata/tests/test_uns.py
@@ -9,10 +9,10 @@ def test_uns_color_subset():
     obs = pd.DataFrame(index=[f"cell{i}" for i in range(5)])
     obs["cat1"] = pd.Series(list("aabcd"), index=obs.index, dtype="category")
     obs["cat2"] = pd.Series(list("aabbb"), index=obs.index, dtype="category")
-    uns = {
-        "cat1_colors": ["red", "green", "blue"],
-        "cat2_colors": ["red", "green", "blue"],
-    }
+    uns = dict(
+        cat1_colors=["red", "green", "blue"],
+        cat2_colors=["red", "green", "blue"],
+    )
 
     adata = AnnData(np.ones((5, 5)), obs=obs, uns=uns)
 


### PR DESCRIPTION
@gokceneraslan

Fixes #257.

When the number of colors was less than the number of categories, subsetting would throw an error. This just resets the colors instead.