### PR TITLE
Restructure aligned_mapping

### DIFF
--- a/anndata/_core/aligned_mapping.py
+++ b/anndata/_core/aligned_mapping.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from collections import abc as cabc
+from types import MappingProxyType
 from typing import Union, Optional, Type, ClassVar, TypeVar  # Special types
 from typing import Hashable, Iterator, Mapping, Sequence  # ABCs
 from typing import Tuple, List, Dict  # Generic base types
@@ -28,14 +29,31 @@ class AlignedMapping(cabc.MutableMapping, ABC):
     to either one or both AnnData axes.
     """
 
+    _axis: Optional[int]
+    _parent: Union["anndata.AnnData", "raw.Raw"]
+
     _allow_df: ClassVar[bool]
     """If this mapping supports heterogeneous DataFrames"""
 
-    _view_class: ClassVar[Type["AlignedViewMixin"]]
+    _View: ClassVar[Type["AlignedView"]]
     """The view class for this aligned mapping."""
 
-    _actual_class: ClassVar[Type["AlignedActualMixin"]]
+    _Actual: ClassVar[Type["AlignedActual"]]
     """The actual class (which has it's own data) for this aligned mapping."""
+
+    def __new__(
+        cls,
+        parent: Union["anndata.AnnData", "raw.Raw"],
+        aligned_to: Union[Optional[int], "AlignedMapping"] = None,
+        *,
+        subset_idx: Optional[OneDIdx] = None,
+        vals: Mapping[str, V] = MappingProxyType({}),
+    ):
+        if isinstance(aligned_to, (int, type(None))):
+            return super().__new__(cls._Actual)
+        else:  # Initialize view
+            assert subset_idx is not None, "A view needs a subset_idx"
+            return super().__new__(cls._View)
 
     def __repr__(self):
         return f"{type(self).__name__} with keys: {', '.join(self.keys())}"
@@ -80,22 +98,22 @@ class AlignedMapping(cabc.MutableMapping, ABC):
     def parent(self) -> Union["anndata.AnnData", "raw.Raw"]:
         return self._parent
 
-    def copy(self):
-        d = self._actual_class(self.parent, self._axis)
+    def copy(self) -> "_Actual":
+        d = self._Actual(self.parent, getattr(self, "_axis", None))
         for k, v in self.items():
             d[k] = v.copy()
         return d
 
-    def _view(self, parent: "anndata.AnnData", subset_idx: I):
+    def _view(self, parent: "anndata.AnnData", subset_idx: I) -> "_View":
         """Returns a subset copy-on-write view of the object."""
-        return self._view_class(self, parent, subset_idx)
+        return self._View(parent, self, subset_idx=subset_idx)
 
     @deprecated("dict(obj)")
     def as_dict(self) -> dict:
         return dict(self)
 
 
-class AlignedViewMixin:
+class AlignedView(AlignedMapping, ABC):
     parent: "anndata.AnnData"
     """Reference to parent AnnData view"""
 
@@ -105,7 +123,16 @@ class AlignedViewMixin:
     parent_mapping: Mapping[Hashable, V]
     """The object this is a view of."""
 
+    subset_idx: I
+    """The subset into the parent AnnData"""
+
     is_view = True
+
+    def __getnewargs_ex__(self):
+        """For pickling support, we need to reconstruct __new__’s args"""
+        args = self.parent, self.parent_mapping
+        kw = dict(subset_idx=self.subset_idx)
+        return args, kw
 
     def __getitem__(self, key: Hashable) -> V:
         return as_view(
@@ -137,11 +164,17 @@ class AlignedViewMixin:
         return len(self.parent_mapping)
 
 
-class AlignedActualMixin:
+class AlignedActual(AlignedMapping, ABC):
     _data: Dict[Hashable, V]
     """Underlying mapping to the data"""
 
     is_view = False
+
+    def __getnewargs_ex__(self):
+        """For pickling support, we need to reconstruct __new__’s args"""
+        args = self.parent, getattr(self, "_axis", None)
+        kw = dict(vals=self._data)
+        return args, kw
 
     def __getitem__(self, key: Hashable) -> V:
         return self._data[key]
@@ -163,11 +196,35 @@ class AlignedActualMixin:
         return len(self._data)
 
 
-class AxisArraysBase(AlignedMapping):
+def _set_qualname(cls: Type):
+    """
+    Correctly sets `__[qual]name__` and renames the `module.__dict__` entry
+    so pickling still works. Bonus: Autocompletion suggests full qualname:
+    aligned_mapping.<tab> → ..., AxisArrays, AxisArrays._Actual, ...
+    """
+    import sys
+
+    for suffix in ["Actual", "View"]:
+        if suffix not in cls.__name__:
+            continue
+        old = cls.__qualname__
+        # _FooActual → Foo._Actual
+        cls.__qualname__ = old.replace("_", "").replace(suffix, f"._{suffix}")
+        cls.__name__ = f"_{suffix}"
+
+        setattr(sys.modules[__name__], cls.__qualname__, cls)
+        delattr(sys.modules[__name__], old)
+        return cls
+
+
+class AxisArrays(AlignedMapping, ABC):
     """
     Mapping of key→array-like,
     where array-like is aligned to an axis of parent AnnData.
     """
+
+    _axis: int
+    dim_names: pd.Index
 
     _allow_df = True
     _dimnames = ("obs", "var")
@@ -186,7 +243,7 @@ class AxisArraysBase(AlignedMapping):
         """Name of the dimension this aligned to."""
         return self._dimnames[self._axis]
 
-    def flipped(self) -> "AxisArraysBase":
+    def flipped(self) -> "AxisArrays":
         """Transpose."""
         new = self.copy()
         new.dimension = abs(self._axis - 1)
@@ -214,28 +271,26 @@ class AxisArraysBase(AlignedMapping):
         return super()._validate_value(val, key)
 
 
-class AxisArrays(AlignedActualMixin, AxisArraysBase):
+class _AxisArraysActual(AlignedActual, AxisArrays):
     def __init__(
         self,
         parent: Union["anndata.AnnData", "raw.Raw"],
         axis: int,
-        vals: Union[Mapping, AxisArraysBase, None] = None,
+        vals: Mapping[str, V] = MappingProxyType({}),
     ):
         self._parent = parent
-        if axis not in (0, 1):
-            raise ValueError()
+        assert axis in (0, 1)
         self._axis = axis
         self.dim_names = (parent.obs_names, parent.var_names)[self._axis]
         self._data = dict()
-        if vals is not None:
-            self.update(vals)
+        self.update(vals)
 
 
-class AxisArraysView(AlignedViewMixin, AxisArraysBase):
+class _AxisArraysView(AlignedView, AxisArrays):
     def __init__(
         self,
-        parent_mapping: AxisArraysBase,
         parent_view: "anndata.AnnData",
+        parent_mapping: AxisArrays,
         subset_idx: OneDIdx,
     ):
         self.parent_mapping = parent_mapping
@@ -245,11 +300,11 @@ class AxisArraysView(AlignedViewMixin, AxisArraysBase):
         self.dim_names = parent_mapping.dim_names[subset_idx]
 
 
-AxisArraysBase._view_class = AxisArraysView
-AxisArraysBase._actual_class = AxisArrays
+AxisArrays._View = _set_qualname(_AxisArraysView)
+AxisArrays._Actual = _set_qualname(_AxisArraysActual)
 
 
-class LayersBase(AlignedMapping):
+class Layers(AlignedMapping, ABC):
     """
     Mapping of key: array-like, where array-like is aligned to both axes of the
     parent anndata.
@@ -259,29 +314,25 @@ class LayersBase(AlignedMapping):
     attrname = "layers"
     axes = (0, 1)
 
-    # TODO: I thought I had a more elegant solution to overiding this...
-    def copy(self) -> "Layers":
-        d = self._actual_class(self.parent)
-        for k, v in self.items():
-            d[k] = v.copy()
-        return d
 
-
-class Layers(AlignedActualMixin, LayersBase):
-    def __init__(
-        self, parent: "anndata.AnnData", vals: Optional[Mapping] = None
-    ):
-        self._parent = parent
-        self._data = dict()
-        if vals is not None:
-            self.update(vals)
-
-
-class LayersView(AlignedViewMixin, LayersBase):
+class _LayersActual(AlignedActual, Layers):
     def __init__(
         self,
-        parent_mapping: LayersBase,
+        parent: "anndata.AnnData",
+        axis: None = None,
+        vals: Mapping[str, V] = MappingProxyType({}),
+    ):
+        assert axis is None
+        self._parent = parent
+        self._data = dict()
+        self.update(vals)
+
+
+class _LayersView(AlignedView, Layers):
+    def __init__(
+        self,
         parent_view: "anndata.AnnData",
+        parent_mapping: Layers,
         subset_idx: TwoDIdx,
     ):
         self.parent_mapping = parent_mapping
@@ -289,15 +340,17 @@ class LayersView(AlignedViewMixin, LayersBase):
         self.subset_idx = subset_idx
 
 
-LayersBase._view_class = LayersView
-LayersBase._actual_class = Layers
+Layers._View = _set_qualname(_LayersView)
+Layers._Actual = _set_qualname(_LayersActual)
 
 
-class PairwiseArraysBase(AlignedMapping):
+class PairwiseArrays(AlignedMapping, ABC):
     """
     Mapping of key: array-like, where both axes of array-like are aligned to
     one axis of the parent anndata.
     """
+
+    _axis: int
 
     _allow_df = False
     _dimnames = ("obs", "var")
@@ -317,27 +370,25 @@ class PairwiseArraysBase(AlignedMapping):
         return self._dimnames[self._axis]
 
 
-class PairwiseArrays(AlignedActualMixin, PairwiseArraysBase):
+class _PairwiseArraysActual(AlignedActual, PairwiseArrays):
     def __init__(
         self,
         parent: "anndata.AnnData",
         axis: int,
-        vals: Optional[Mapping] = None,
+        vals: Mapping[str, V] = MappingProxyType({}),
     ):
         self._parent = parent
-        if axis not in (0, 1):
-            raise ValueError()
+        assert axis in (0, 1)
         self._axis = axis
         self._data = dict()
-        if vals is not None:
-            self.update(vals)
+        self.update(vals)
 
 
-class PairwiseArraysView(AlignedViewMixin, PairwiseArraysBase):
+class _PairwiseArraysView(AlignedView, PairwiseArrays):
     def __init__(
         self,
-        parent_mapping: PairwiseArraysBase,
         parent_view: "anndata.AnnData",
+        parent_mapping: PairwiseArrays,
         subset_idx: OneDIdx,
     ):
         self.parent_mapping = parent_mapping
@@ -346,5 +397,5 @@ class PairwiseArraysView(AlignedViewMixin, PairwiseArraysBase):
         self._axis = parent_mapping._axis
 
 
-PairwiseArraysBase._view_class = PairwiseArraysView
-PairwiseArraysBase._actual_class = PairwiseArrays
+PairwiseArrays._View = _set_qualname(_PairwiseArraysView)
+PairwiseArrays._Actual = _set_qualname(_PairwiseArraysActual)

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -26,14 +26,7 @@ from scipy.sparse import issparse
 from .raw import Raw
 from .index import _normalize_indices, _subset, Index, Index1D
 from .file_backing import AnnDataFileManager
-from .aligned_mapping import (
-    AxisArrays,
-    AxisArraysView,
-    PairwiseArrays,
-    PairwiseArraysView,
-    Layers,
-    LayersView,
-)
+from .aligned_mapping import AxisArrays, PairwiseArrays, Layers
 from .views import (
     ArrayView,
     DictView,
@@ -505,7 +498,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         self._clean_up_old_format(uns)
 
         # layers
-        self._layers = Layers(self, layers)
+        self._layers = Layers(self, vals=convert_to_dict(layers))
 
     def __sizeof__(self) -> int:
         size = 0
@@ -655,7 +648,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             )
 
     @property
-    def layers(self) -> Union[Layers, LayersView]:
+    def layers(self) -> Layers:
         """\
         Dictionary-like object with values of the same dimensions as :attr:`X`.
 
@@ -809,7 +802,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         self.uns = OrderedDict()
 
     @property
-    def obsm(self) -> Union[AxisArrays, AxisArraysView]:
+    def obsm(self) -> AxisArrays:
         """\
         Multi-dimensional annotation of observations
         (mutable structured :class:`~numpy.ndarray`).
@@ -833,7 +826,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         self.obsm = dict()
 
     @property
-    def varm(self) -> Union[AxisArrays, AxisArraysView]:
+    def varm(self) -> AxisArrays:
         """\
         Multi-dimensional annotation of variables/ features
         (mutable structured :class:`~numpy.ndarray`).
@@ -857,7 +850,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         self.varm = dict()
 
     @property
-    def obsp(self) -> Union[PairwiseArrays, PairwiseArraysView]:
+    def obsp(self) -> PairwiseArrays:
         """\
         Pairwise annotation of observations,
         a mutable mapping with array-like values.
@@ -881,7 +874,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         self.obsp = dict()
 
     @property
-    def varp(self) -> Union[PairwiseArrays, PairwiseArraysView]:
+    def varp(self) -> PairwiseArrays:
         """\
         Pairwise annotation of observations,
         a mutable mapping with array-like values.

--- a/anndata/_core/raw.py
+++ b/anndata/_core/raw.py
@@ -6,9 +6,10 @@ import pandas as pd
 from scipy import sparse
 from scipy.sparse import issparse
 
+from ..utils import convert_to_dict
 from . import anndata
 from .index import _normalize_index, _subset, unpack_index
-from .aligned_mapping import AxisArrays, AxisArraysView
+from .aligned_mapping import AxisArrays
 from .sparse_dataset import SparseDataset
 
 
@@ -29,11 +30,11 @@ class Raw:
         if adata.isbacked == (X is None):
             self._X = X
             self._var = _gen_dataframe(var, self.X.shape[1], ['var_names'])
-            self._varm = AxisArrays(self, 1, varm)
+            self._varm = AxisArrays(self, 1, vals=convert_to_dict(varm))
         elif X is None:  # construct from adata
             self._X = adata.X.copy()
             self._var = adata.var.copy()
-            self._varm = AxisArrays(self, 1, adata.varm.copy())
+            self._varm = AxisArrays(self, 1, vals=adata.varm)
         elif adata.isbacked:
             raise ValueError("Cannot specify X if adata is backed")
 

--- a/anndata/tests/test_layers.py
+++ b/anndata/tests/test_layers.py
@@ -62,6 +62,20 @@ def test_set_dataframe(homogenous, df, dtype):
     assert np.issubdtype(adata.layers["df"].dtype, dtype)
 
 
+def test_pickle():
+    import pickle
+    from anndata._core.aligned_mapping import Layers
+
+    adata = AnnData(X=X, layers=dict(L=L.copy()))
+
+    pickle_data = pickle.dumps(adata.layers)
+    layers: Layers = pickle.loads(pickle_data)
+    assert np.allclose(layers.parent.X, adata.X)
+    assert layers.keys() == adata.layers.keys()
+    for new, old in zip(layers.values(), adata.layers.values()):
+        assert np.allclose(new, old)
+
+
 def test_readwrite(backing_h5ad):
     adata = AnnData(X=X, layers=dict(L=L.copy()))
     adata.write(backing_h5ad)


### PR DESCRIPTION
This converts the `AlignedMapping` type hierarchy into something like pathlib.

AxisArrays, PairwiseArrays and Layers are now abstract superclasses of their view and actual variants,
and used to construct them using `__new__`.