### PR TITLE
Avoid int-named obs_names and var_names.

### DIFF
--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -114,6 +114,15 @@ def test_names():
     assert adata.var_names.tolist() == ["a", "b"]
 
 
+def test_index_names():
+    adata = adata_dense.copy()
+    assert adata.obs_names.name is None
+    adata.obs_names = pd.Series(["AAD", "CCA"], name="barcodes")
+    assert adata.obs_names.name == "barcodes"
+    adata.obs_names = pd.Series(["x", "y"], name=0)  # happens, but we strip it
+    assert adata.obs_names.name is None
+
+
 def test_indices_dtypes():
     adata = AnnData(
         np.array([[1, 2, 3], [4, 5, 6]]),


### PR DESCRIPTION
obs_names & var_names are instances of pandas.Index, and can have a .name.
We try to write that name to disk as zarr/hdf5. At least HDF5 doesn’t support ints as names.

Fixes #286