### PR TITLE
Fix unnecessary copy in strings_to_categoricals

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1138,6 +1138,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                         "AnnData, not on this view. You might encounter this"
                         "error message while copying or writing to disk."
                     )
+                if self.is_view:
+                    warnings.warn(
+                        "Initializing view as actual.", ImplicitModificationWarning
+                    )
+                # If `self` is a view, it will be actualized in the next line,
+                # therefore the previous warning
                 df[key] = c
                 logger.info(f"... storing {key!r} as categorical")
 

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1114,14 +1114,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         dont_modify = False  # only necessary for backed views
         if df is None:
             dfs = [self.obs, self.var]
-            if self.is_view:
-                if not self.isbacked:
-                    warnings.warn(
-                        "Initializing view as actual.", ImplicitModificationWarning,
-                    )
-                    self._init_as_actual(self.copy())
-                else:
-                    dont_modify = True
+            if self.is_view and self.isbacked:
+                dont_modify = True
         else:
             dfs = [df]
         for df in dfs:

--- a/anndata/tests/test_raw.py
+++ b/anndata/tests/test_raw.py
@@ -82,7 +82,8 @@ def test_raw_view_rw(adata_raw, backing_h5ad):
     # Make sure it still writes correctly if the object is a view
     adata_raw_view = adata_raw[:, adata_raw.var_names]
     assert_equal(adata_raw_view, adata_raw)
-    adata_raw_view.write(backing_h5ad)
+    with pytest.warns(ImplicitModificationWarning, match="Initializing view as actual"):
+        adata_raw_view.write(backing_h5ad)
     adata_read = ad.read(backing_h5ad)
 
     assert_equal(adata_read, adata_raw_view, exact=True)


### PR DESCRIPTION
Part of a fix for https://github.com/theislab/scanpy/issues/1000

Prevents calling strings_to_categoricals from turning an `view` to `actual` if no modification would occur.

Additionally I've updated some tests for backed raw which were catching a warning from this.