### PR TITLE
Remove mention of rc for prettier docs

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,11 +13,11 @@
    - Square matrices in :attr:`~anndata.AnnData.uns` will no longer be sliced (use `.{obs,var}p` instead).
 
 
-0.7rc1 :small:`December 23, 2019`
----------------------------------
+0.7 :small:`January 22, 2020`
+-----------------------------
 
 .. warning::
-   Breaking changes introduced between 0.6.22.post1 and 0.7rc1:
+   Breaking changes introduced between 0.6.22.post1 and 0.7:
 
    - Elements of :class:`~anndata.AnnData`\ s don’t have their dimensionality reduced when the main object is subset.
      This is to maintain consistency when subsetting. See discussion in :issue:`145`.


### PR DESCRIPTION
That’s probably less confusing for people who don’t know what rc versions are.

I’ll also add a “stable” branch pointing to this so readthedocs will use it. We have to delete that when doing the next release.