### PR TITLE
Fix index setting when initializing AnnData with DataFrames

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -395,6 +395,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         # various ways of initializing the data
         # ----------------------------------------------------------------------
 
+        # If X is a data frame, we store its indices for verification
+        x_indices = []
+
         # init from file
         if filename is not None:
             self.file = AnnDataFileManager(self, filename, filemode)
@@ -422,16 +425,15 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
             # init from DataFrame
             elif isinstance(X, pd.DataFrame):
+                # to verify index matching, we wait until obs and var are DataFrames
                 if obs is None:
                     obs = pd.DataFrame(index=X.index)
-                else:
-                    if not X.index.equals(obs.index):
-                        raise ValueError("Index of obs must match index of X.")
+                elif not isinstance(X.index, pd.RangeIndex):
+                    x_indices.append(("obs", "index", X.index))
                 if var is None:
                     var = pd.DataFrame(index=X.columns)
-                else:
-                    if not X.columns.equals(var.index):
-                        raise ValueError("Index of var must match columns of X.")
+                elif not isinstance(X.columns, pd.RangeIndex):
+                    x_indices.append(("var", "columns", X.columns))
                 X = ensure_df_homogeneous(X, "X")
 
         # ----------------------------------------------------------------------
@@ -482,10 +484,16 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                         raise ValueError("`shape` is inconsistent with `var`")
 
         # annotations
-        self._obs = _gen_dataframe(
-            obs, self._n_obs, ["obs_names", "row_names", "smp_names"]
-        )
+        self._obs = _gen_dataframe(obs, self._n_obs, ["obs_names", "row_names"],)
         self._var = _gen_dataframe(var, self._n_vars, ["var_names", "col_names"])
+
+        # now we can verify if indices match!
+        for attr_name, x_name, idx in x_indices:
+            attr = getattr(self, attr_name)
+            if isinstance(attr.index, pd.RangeIndex):
+                attr.index = idx
+            elif not idx.equals(attr.index):
+                raise ValueError(f"Index of {attr_name} must match {x_name} of X.")
 
         # unstructured annotations
         self._uns = uns or OrderedDict()

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -484,7 +484,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                         raise ValueError("`shape` is inconsistent with `var`")
 
         # annotations
-        self._obs = _gen_dataframe(obs, self._n_obs, ["obs_names", "row_names"],)
+        self._obs = _gen_dataframe(obs, self._n_obs, ["obs_names", "row_names"])
         self._var = _gen_dataframe(var, self._n_vars, ["var_names", "col_names"])
 
         # now we can verify if indices match!

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -82,6 +82,12 @@ def test_create_from_df_with_obs_and_var():
         AnnData(df, var=var.reset_index())
 
 
+def test_from_df_and_dict():
+    df = pd.DataFrame(dict(a=[0.1, 0.2, 0.3], b=[1.1, 1.2, 1.3]))
+    adata = AnnData(df, dict(species=pd.Categorical(["a", "b", "a"])))
+    assert adata.obs["species"].values.tolist() == ["a", "b", "a"]
+
+
 def test_df_warnings():
     df = pd.DataFrame(dict(A=[1, 2, 3], B=[1.0, 2.0, 3.0]), index=["a", "b", "c"])
     with pytest.warns(UserWarning, match=r"X.*dtype float64"):


### PR DESCRIPTION
The logic was dodgy, see e.g. the added test case which would throw an exception, as we don’t check if the `obs` parameter is a DataFrame before accessing its `index`:

https://github.com/theislab/anndata/blob/fa7d1bf4c3b51aa310b6cf62410443aa8bf4f521/anndata/_core/anndata.py#L424-L428

Now we take the indices from any DataFrame provided. When two indices are present for an axis, they will be compared (In both steps, “RangeIndex” counts as “no index”). It works like this:

1. If obs/var is a thing that could gain an index in conversion later (DataFrame, dict) and X.index/columns isn’t an (probably autogenerated) RangeIndex we mark it for comparison.

   https://github.com/theislab/anndata/blob/b4008ed747d64d7cc5bdfe6ddaf7f40543cd81e2/anndata/_core/anndata.py#L429-L432

2. After conversion, we set the index if there was none before, or compare the two possibly clashing indices for the same axis:

   https://github.com/theislab/anndata/blob/b4008ed747d64d7cc5bdfe6ddaf7f40543cd81e2/anndata/_core/anndata.py#L491-L496