### PR TITLE
Fix doc builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,3 +2,5 @@ build:
   image: latest
 python:
   version: 3.6
+  install:
+    - requirements: docs/requirements.txt

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -215,8 +215,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
     :attr:`layers`.
 
     Indexing into an AnnData object can be performed by relative position
-    with numeric indices (like pandas’ :attr:`~pandas.DataFrame.iloc`),
-    or by labels (like :attr:`~pandas.DataFrame.loc`).
+    with numeric indices (like pandas’ :meth:`~pandas.DataFrame.iloc`),
+    or by labels (like :meth:`~pandas.DataFrame.loc`).
     To avoid ambiguity with numeric indexing into observations or variables,
     indexes of the AnnData object are converted to strings by the constructor.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,16 +1,11 @@
+# Anndata dependencies
+-r ../requirements.txt
+
 # stuff necessary for docs generation
 setuptools_scm
-importlib_metadata>=0.7; python_version < '3.8'
 typing_extensions; python_version < '3.8'
 # Sphinx 2 has nicer looking sections
 sphinx>=2.0.1
 sphinx-autodoc-typehints
 scanpydoc>=0.4.2
 sphinx_issues
-
-# dependencies of anndata
-pandas~=0.21
-scipy
-h5py
-natsort
-zarr

--- a/docs/requires.txt
+++ b/docs/requires.txt
@@ -1,0 +1,1 @@
+requirements.txt


### PR DESCRIPTION
* Docs were trying to build against an old version of pandas.
* I've also updated documentation requirements file to be a bit more idiomatic.
* Also fixed some reference that were breaking builds.
* Added a symlink from docs/requirements.txt to `docs/requires.txt`, even though readthedocs says using the config should override the webform.