### PR TITLE
Fix indexers like adata[adata[:, gene].X > 0]

### DIFF
--- a/anndata/_core/index.py
+++ b/anndata/_core/index.py
@@ -72,11 +72,10 @@ def _normalize_index(
     elif isinstance(indexer, str):
         return index.get_loc(indexer)  # int
     elif isinstance(indexer, (Sequence, np.ndarray, pd.Index, spmatrix, np.matrix)):
-        # fmt: off
-        if (
-            hasattr(indexer, "shape") and
-            ((indexer.shape == (index.shape[0], 1)) or (indexer.shape == (1, index.shape[0])))
-        ):  # fmt: on
+        if hasattr(indexer, "shape") and (
+            (indexer.shape == (index.shape[0], 1))
+            or (indexer.shape == (1, index.shape[0]))
+        ):
             if isinstance(indexer, spmatrix):
                 indexer = indexer.toarray()
             indexer = np.ravel(indexer)

--- a/anndata/_core/index.py
+++ b/anndata/_core/index.py
@@ -72,10 +72,11 @@ def _normalize_index(
     elif isinstance(indexer, str):
         return index.get_loc(indexer)  # int
     elif isinstance(indexer, (Sequence, np.ndarray, pd.Index, spmatrix, np.matrix)):
+        # fmt: off
         if (
             hasattr(indexer, "shape") and
             ((indexer.shape == (index.shape[0], 1)) or (indexer.shape == (1, index.shape[0])))
-        ):
+        ):  # fmt: on
             if isinstance(indexer, spmatrix):
                 indexer = indexer.toarray()
             indexer = np.ravel(indexer)

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -2,6 +2,7 @@ from functools import singledispatch, wraps
 from string import ascii_letters
 from typing import Tuple
 from collections.abc import Mapping
+import warnings
 
 import h5py
 import numpy as np
@@ -175,6 +176,21 @@ def array_bool_subset(index, min_size=2):
     return b
 
 
+def matrix_bool_subset(index, min_size=2):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", PendingDeprecationWarning)
+        indexer = np.matrix(
+            array_bool_subset(index, min_size=min_size).reshape(len(index), 1)
+        )
+    return indexer
+
+
+def spmatrix_bool_subset(index, min_size=2):
+    return sparse.csr_matrix(
+        array_bool_subset(index, min_size=min_size).reshape(len(index), 1)
+    )
+
+
 def array_subset(index, min_size=2):
     if len(index) < min_size:
         raise ValueError(
@@ -217,6 +233,8 @@ def single_subset(index):
         single_subset,
         array_int_subset,
         array_bool_subset,
+        matrix_bool_subset,
+        spmatrix_bool_subset,
     ]
 )
 def subset_func(request):

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 import anndata as ad
+from anndata._core.index import _normalize_index
 
 from anndata.tests.helpers import (
     gen_adata,
@@ -254,7 +255,9 @@ def test_not_set_subset_X(matrix_type, subset_func):
 
     subset = adata[:, subset_idx]
 
-    internal_idx = subset_func(np.arange(subset.X.shape[1]))
+    internal_idx = _normalize_index(
+        subset_func(np.arange(subset.X.shape[1])), subset.var_names
+    )
     assert subset.is_view
     subset.X[:, internal_idx] = 1
     assert not subset.is_view
@@ -289,7 +292,10 @@ def test_set_subset_obsm(adata, subset_func):
             break
     subset = adata[subset_idx, :]
 
-    internal_idx = subset_func(np.arange(subset.obsm["o"].shape[0]))
+    internal_idx = _normalize_index(
+        subset_func(np.arange(subset.obsm["o"].shape[0])), subset.obs_names
+    )
+
     assert subset.is_view
     subset.obsm["o"][internal_idx] = 1
     assert not subset.is_view
@@ -308,7 +314,10 @@ def test_set_subset_varm(adata, subset_func):
             break
     subset = adata[:, subset_idx]
 
-    internal_idx = subset_func(np.arange(subset.varm["o"].shape[0]))
+    internal_idx = _normalize_index(
+        subset_func(np.arange(subset.varm["o"].shape[0])), subset.var_names
+    )
+
     assert subset.is_view
     subset.varm["o"][internal_idx] = 1
     assert not subset.is_view


### PR DESCRIPTION
Previously, this returned a 1d array. Now it's 2d. This PR implicitly flattens 2d arrays in indexers when one of the dimensions has length 1.

Fixes #333

Still needs tests.