### PR TITLE
Fix ArrayView and numpy subclassing

### DIFF
--- a/anndata/_core/views.py
+++ b/anndata/_core/views.py
@@ -69,9 +69,8 @@ class ArrayView(_SetItemMixin, np.ndarray):
         input_array: Sequence[Any],
         view_args: Tuple["anndata.AnnData", str, Tuple[str, ...]] = None,
     ):
-        if not isinstance(input_array, np.ndarray):
-            input_array = np.array(input_array)
-        arr = input_array.view(cls)
+        arr = np.asanyarray(input_array).view(cls)
+
         if view_args is not None:
             view_args = ViewArgs(*view_args)
         arr._view_args = view_args

--- a/anndata/_core/views.py
+++ b/anndata/_core/views.py
@@ -69,7 +69,9 @@ class ArrayView(_SetItemMixin, np.ndarray):
         input_array: Sequence[Any],
         view_args: Tuple["anndata.AnnData", str, Tuple[str, ...]] = None,
     ):
-        arr = np.asarray(input_array).view(cls)
+        if not isinstance(input_array, np.ndarray):
+            input_array = np.array(input_array)
+        arr = input_array.view(cls)
         if view_args is not None:
             view_args = ViewArgs(*view_args)
         arr._view_args = view_args

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -40,7 +40,7 @@ subset_func2 = subset_func
 
 
 class NDArraySubclass(np.ndarray):
-    def view(self, type=None, dtype=None):
+    def view(self, dtype=None, type=None):
         return self
 
 

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -39,6 +39,11 @@ uns_dict = dict(oanno1_colors=["#000000", "#FFFFFF"], uns2=["some annotation"])
 subset_func2 = subset_func
 
 
+class NDArraySubclass(np.ndarray):
+    def view(self, type=None, dtype=None):
+        return self
+
+
 @pytest.fixture
 def adata():
     adata = ad.AnnData(np.zeros((100, 100)))
@@ -450,3 +455,13 @@ def test_double_index(subset_func, subset_func2):
     assert np.all(asarray(v1.X) == asarray(v2.X))
     assert np.all(v1.obs == v2.obs)
     assert np.all(v1.var == v2.var)
+
+
+def test_view_retains_ndarray_subclass():
+    adata = ad.AnnData(np.zeros((10, 10)))
+    adata.obsm['foo'] = np.zeros((10, 5)).view(NDArraySubclass)
+
+    view = adata[:5, :]
+
+    assert isinstance(view.obsm['foo'], NDArraySubclass)
+    assert view.obsm['foo'].shape == (5, 5)

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -459,9 +459,9 @@ def test_double_index(subset_func, subset_func2):
 
 def test_view_retains_ndarray_subclass():
     adata = ad.AnnData(np.zeros((10, 10)))
-    adata.obsm['foo'] = np.zeros((10, 5)).view(NDArraySubclass)
+    adata.obsm["foo"] = np.zeros((10, 5)).view(NDArraySubclass)
 
     view = adata[:5, :]
 
-    assert isinstance(view.obsm['foo'], NDArraySubclass)
-    assert view.obsm['foo'].shape == (5, 5)
+    assert isinstance(view.obsm["foo"], NDArraySubclass)
+    assert view.obsm["foo"].shape == (5, 5)

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -40,7 +40,7 @@ subset_func2 = subset_func
 
 
 class NDArraySubclass(np.ndarray):
-    def view(self, dtype=None, type=None):
+    def view(self, dtype=None, typ=None):
         return self
 
 


### PR DESCRIPTION
Hi,
I have a `numpy.ndarray` subclass with some column annotations (also `ndarrays`), including a
view-like object. Problem is that taking view of `adata` object first converts this to `np.ndarray`,
effectively removing my subclass (`arr = np.asarray(input_array)`). This PR fixes this such that only non-arrays are converted to arrays, rest is left the same.