### PR TITLE
[draft] html repr

### DIFF
--- a/anndata/_core/aligned_mapping.py
+++ b/anndata/_core/aligned_mapping.py
@@ -73,6 +73,11 @@ class AlignedMapping(cabc.MutableMapping, ABC):
         pass
 
     @property
+    def dims(self) -> Tuple[str, ...]:
+        """Which dimensions of the parent is this aligned to?"""
+        return tuple(("obs", "var")[i] for i in self.axes)
+
+    @property
     @abstractmethod
     def is_view(self) -> bool:
         pass

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -588,6 +588,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         else:
             return self._gen_repr(self.n_obs, self.n_vars)
 
+
+    def _ipython_display_(self):
+        from .html_repr import as_tree
+        return as_tree(self, opened=False)._ipython_display_()
+
+
     def __eq__(self, other):
         """Equality testing"""
         raise NotImplementedError(

--- a/anndata/_core/html_repr.py
+++ b/anndata/_core/html_repr.py
@@ -1,0 +1,117 @@
+from functools import singledispatch
+from collections.abc import Mapping
+
+from ipytree import Tree, Node
+
+import numpy as np
+from scipy import sparse
+import pandas as pd
+
+import anndata as ad
+
+
+def anndata_descr(x: ad.AnnData) -> str:
+    descr = f"AnnData object with {x.n_obs} obs × {x.n_vars} vars"
+    if x.is_view:
+        descr = "View of " + descr
+    if x.isbacked:
+        descr += f" backed at '{x.filename}'"
+    return descr
+
+
+def format_name(name):
+    return f"<code><b>{name}</code></b>"
+
+
+def as_tree(x: ad.AnnData, **kwargs) -> Tree:
+    tree = Tree(stripes=True)
+    root = Node(anndata_descr(x), icon="sitemap")
+    tree.add_node(root)
+    elnames = ["X", "obs", "var", "layers", "obsm", "varm", "obsp", "varp", "uns"]
+    for elname in elnames:
+        el = getattr(x, elname)
+        if isinstance(el, Mapping) and len(el) == 0:
+            continue
+        root.add_node(as_node(el, elname, **kwargs))
+    return tree
+
+
+@singledispatch
+def as_node(x, name: str, **kwargs):
+    raise NotImplementedError(f"Not implemented for type {type(x)}")
+
+
+@as_node.register
+def as_node_mapping(x: Mapping, name: str, **kwargs):
+    node = Node(format_name(name), icon="sitemap", **kwargs)
+    for k, v in x.items():
+        node.add_node(as_node(v, name=k, **kwargs))
+    return node
+
+
+@as_node.register
+def as_node_alignedmapping(
+    x: ad._core.aligned_mapping.AlignedMapping, name: str, **kwargs
+):
+    node = Node(
+        f"{format_name(name)}: <code>Mapping</code> aligned to <code>{x.dims}</code> with <code>{len(x)}</code> entries.",
+        icon="clone",
+        **kwargs,
+    )
+    for k, v in x.items():
+        node.add_node(as_node(v, name=k, **kwargs))
+    return node
+
+
+# @as_node.registed(ad.SparseDataset)
+# @as_node.register(h5py.DataSet)
+@as_node.register(np.ndarray)
+def as_node_arr(x: np.ndarray, name: str, icon="square", **kwargs):
+    return Node(
+        f"{format_name(name)}: <code>{type(x).__name__}</code> of shape <code>{'×'.join(map(str, x.shape))}</code> and dtype <code>{x.dtype}</code>",
+        icon=icon,
+        **kwargs,
+    )
+
+
+@as_node.register
+def as_node_df(x: pd.DataFrame, name: str, **kwargs):
+    node = Node(
+        f"{format_name(name)}: <code>{type(x).__name__}</code> of shape <code>{'×'.join(map(str, x.shape))}</code>",
+        icon="table",
+        **kwargs,
+    )
+    for k, v in x.items():
+        node.add_node(as_node(v, name=k, **kwargs))
+    return node
+
+
+@as_node.register
+def as_node_series(x: pd.Series, name: str, **kwargs):
+    return Node(
+        f"{format_name(name)}: <code>{type(x).__name__}</code> with dtype <code>{x.dtype}</code>",
+        icon="columns",
+        **kwargs,
+    )
+
+
+@as_node.register
+def as_node_sparse(x: sparse.spmatrix, name: str, **kwargs):
+    return as_node_arr(x, name, **kwargs)
+
+
+@as_node.register(type(None))
+@as_node.register(int)
+@as_node.register(float)
+@as_node.register(bool)
+@as_node.register(np.bool_)
+@as_node.register(np.number)
+@as_node.register(np.string_)
+@as_node.register(np.str_)
+@as_node.register(np.str)
+def as_node_scalar(x, name: str, **kwargs):
+    return Node(
+        f"{format_name(name)}: <code>{repr(x)}</code> (<code>{type(x).__name__}</code>)",
+        icon="minus",
+        **kwargs,
+    )


### PR DESCRIPTION
@flying-sheep @falexwolf

Draft implementation of the html repr I had been talking about. It's an expandable tree that lets you look into your anndata object. If you have some time, I'd love to get some feedback on how this looks and what information should be presented.

Here's a static representation, but I'd recommend checking out this branch and trying it:

<img width="464" alt="image" src="https://user-images.githubusercontent.com/8238804/77508657-501b5980-6ebf-11ea-8dc0-9ff07541ee75.png">

This is still very WIP, so a few key things are still TODO:

- [ ] Efficient generation for views (currently copies all elements due to access)
- [ ] Support for backed arrays (should be pretty easy)
- [ ] Fallback if ipytree isn't installed
- [ ] Fallback for unrecognized types

I'd also like to consider not using `ipytree`, and just returning some plain html. `ipytree` seems like it was built for a different usecase, and I don't think this needs to be a widget. Ideally this would be a bit lighter weight.