### PR TITLE
Concatenate restructure & outer join for layers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - "pip install docutils"
   - "pip install -e ."
 script:
-  - pytest --doctest-modules --cov=. --cov-report=xml
+  - pytest --cov=. --cov-report=xml
   - python setup.py check --restructuredtext --strict
   - rst2html.py --halt=2 README.rst >/dev/null
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - "pip install docutils"
   - "pip install -e ."
 script:
-  - pytest --cov=. --cov-report=xml
+  - pytest --doctest-modules --cov=. --cov-report=xml
   - python setup.py check --restructuredtext --strict
   - rst2html.py --halt=2 README.rst >/dev/null
 after_success:

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1672,13 +1672,21 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             adatas = adatas[0]  # backwards compatibility
         all_adatas = (self,) + tuple(adatas)
 
-        return concat(
+        out = concat(
             all_adatas,
             join=join,
             batch_key=batch_key,
             batch_categories=batch_categories,
             uns_merge=uns_merge,
         )
+
+        # Backwards compat, ordering columns:
+        if batch_categories is None:
+            batch_categories = np.arange(len(all_adatas)).astype(str)
+        pat = rf"-({'|'.join(batch_categories)})$"
+        out.var = out.var.iloc[:, out.var.columns.str.extract(pat, expand=False).fillna("").argsort(kind="stable")]
+
+        return out
 
     def var_names_make_unique(self, join: str = "-"):
         # Important to go through the setter so obsm dataframes are updated too

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -41,7 +41,6 @@ from .views import (
     as_view,
     _resolve_idxs,
 )
-from .merge import merge_uns
 from .sparse_dataset import SparseDataset
 from .. import utils
 from ..utils import convert_to_dict, ensure_df_homogeneous
@@ -1662,235 +1661,24 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                [0., 0., 2., 1.],
                [0., 6., 5., 0.]], dtype=float32)
         """
+        from .merge import concat
+
         if self.isbacked:
             raise ValueError("Currently, concatenate does only work in memory mode.")
 
-        from scipy.sparse import vstack
-
         if len(adatas) == 0:
-            return self
+            return self.copy()
         elif len(adatas) == 1 and not isinstance(adatas[0], AnnData):
-            # wait with raising this warning until numpy starts raising a similar warning, too
-            # warnings.warn(
-            #     "Trying to treat first argument of `concatenate` as sequence "
-            #     "of AnnDatas. Do `AnnData.concatenate(*adata_list)` instead of "
-            #     "`adata_list[0].concatenate(adata_list[1:])`."
-            # )
             adatas = adatas[0]  # backwards compatibility
         all_adatas = (self,) + tuple(adatas)
 
-        # for controlled behavior, make all variable names unique
-        printed_info = False
-        for i, ad in enumerate(all_adatas):
-            if ad.var_names.is_unique:
-                continue
-            ad.var_names = utils.make_index_unique(ad.var_names)
-            if not printed_info:
-                logger.info(
-                    "Making variable names unique for controlled concatenation."
-                )
-                printed_info = True
-
-        # define variable names of joint AnnData
-        mergers = dict(inner=set.intersection, outer=set.union)
-        var_names_reduce = reduce(
-            mergers[join], (set(ad.var_names) for ad in all_adatas)
+        return concat(
+            all_adatas,
+            join=join,
+            batch_key=batch_key,
+            batch_categories=batch_categories,
+            uns_merge=uns_merge,
         )
-        # restore order of initial var_names, append non-sortable names at the end
-        # see how this was done in the repo at commit state
-        # 40a24f
-        var_names = []
-        for v in all_adatas[0].var_names:
-            if v in var_names_reduce:
-                var_names.append(v)
-                var_names_reduce.remove(v)  # update the set
-        var_names = pd.Index(var_names + list(var_names_reduce))
-
-        if batch_categories is None:
-            categories = [str(i) for i, _ in enumerate(all_adatas)]
-        elif len(batch_categories) == len(all_adatas):
-            categories = batch_categories
-        else:
-            raise ValueError("Provide as many `batch_categories` as `adatas`.")
-
-        out_shape = (sum(a.n_obs for a in all_adatas), len(var_names))
-
-        sparse_Xs = [a.X for a in all_adatas if issparse(a.X)]
-        if join == "outer":
-            if sparse_Xs:  # not sure whether the lil_matrix is really the best option
-                X = sparse.lil_matrix(out_shape, dtype=self.X.dtype)
-            else:
-                X = np.empty(out_shape, dtype=self.X.dtype)
-                X[:] = np.nan
-        else:
-            Xs = []
-
-        # create layers dict that contains layers shared among all AnnDatas
-        layers = OrderedDict()
-        shared_layers = [
-            key
-            for key in all_adatas[0].layers.keys()
-            if all([key in ad.layers.keys() for ad in all_adatas])
-        ]
-        for key in shared_layers:
-            layers[key] = []
-
-        # create obsm dict that contains obsm keys shared among all AnnDatas
-        obsm = OrderedDict()
-        shared_obsm_keys = [
-            key
-            for key in all_adatas[0].obsm
-            if all([key in ad.obsm for ad in all_adatas])
-        ]
-        for key in shared_obsm_keys:
-            obsm[key] = []
-
-        # check whether tries to do “outer join” and layers is non_empty.
-        if join == "outer" and len(shared_layers) > 0:
-            logger.info(
-                "layers concatenation is not yet available for 'outer' "
-                "intersection and will be ignored."
-            )
-
-        # check whether layers are not consistently set in all AnnData objects.
-        n_layers = np.array([len(ad.layers.keys()) for ad in all_adatas])
-        if join == "inner" and not all(len(shared_layers) == n_layers):
-            logger.info(
-                "layers are inconsistent - only layers that are shared among "
-                "all AnnData objects are included."
-            )
-
-        var = pd.DataFrame(index=var_names)
-
-        if join == "inner":
-            ad_ref = all_adatas[0]
-            cols_intersect = set(ad_ref.var.columns)
-            for ad in all_adatas[1:]:
-                cols_intersect &= set(ad.var.columns)
-                cols_intersect = {
-                    col
-                    for col in cols_intersect
-                    if ad_ref.var.loc[var_names, col].equals(ad.var.loc[var_names, col])
-                }
-                if not cols_intersect:
-                    break
-
-        obs_i = 0  # start of next adata’s observations in X
-        out_obss = []
-        for i, ad in enumerate(all_adatas):
-            if join == "outer":
-                # only names that are actually present in the current AnnData
-                vars_intersect = [v for v in var_names if v in ad.var_names]
-            else:
-                vars_intersect = var_names
-
-            # X
-            if join == "outer":
-                # this is pretty slow, I guess sparse matrices shouldn’t be
-                # constructed like that
-                idx_obs = slice(obs_i, obs_i + ad.n_obs)
-                idx_var = var_names.isin(vars_intersect)
-                X[idx_obs, idx_var] = ad[:, vars_intersect].X
-            else:
-                Xs.append(ad[:, vars_intersect].X)
-            obs_i += ad.n_obs
-
-            # layers
-            if join == "inner":
-                for key in shared_layers:
-                    layers[key].append(ad[:, vars_intersect].layers[key])
-
-            # obsm
-            for key in shared_obsm_keys:
-                obsm[key].append(ad.obsm[key])
-
-            # obs
-            obs = ad.obs.copy()
-            obs[batch_key] = pd.Categorical(ad.n_obs * [categories[i]], categories)
-            if is_string_dtype(all_adatas[0].obs.index) and not is_string_dtype(
-                ad.obs.index
-            ):
-                obs.index = obs.index.astype(str)
-            if index_unique is not None:
-                if not is_string_dtype(ad.obs.index):
-                    obs.index = obs.index.astype(str)
-                obs.index = obs.index.values + index_unique + categories[i]
-            out_obss.append(obs)
-
-            # var
-            for c in ad.var.columns:
-                if join == "inner" and c in cols_intersect:
-                    if c not in var.columns:
-                        var.loc[vars_intersect, c] = ad.var.loc[vars_intersect, c]
-                    continue
-                new_c = (
-                    c
-                    + (index_unique if index_unique is not None else "-")
-                    + categories[i]
-                )
-                var.loc[vars_intersect, new_c] = ad.var.loc[vars_intersect, c]
-
-        if join == "inner":
-
-            X = vstack(Xs) if sparse_Xs else np.concatenate(Xs)
-
-            for key in shared_layers:
-                if any(issparse(a.layers[key]) for a in all_adatas):
-                    layers[key] = vstack(layers[key])
-                else:
-                    layers[key] = np.concatenate(layers[key])
-
-        # obsm
-        for key in shared_obsm_keys:
-            if any(issparse(a.obsm[key]) for a in all_adatas):
-                obsm[key] = vstack(obsm[key])
-            else:
-                obsm[key] = np.concatenate(obsm[key])
-
-        obs = pd.concat(out_obss, sort=True)
-
-        if sparse_Xs:
-            sparse_format = sparse_Xs[0].getformat()
-            X = X.asformat(sparse_format)
-        if join == "inner":
-            for key in shared_layers:
-                sparse_layers = [
-                    a.layers[key] for a in all_adatas if issparse(a.layers[key])
-                ]
-                if sparse_layers:
-                    sparse_format_l = sparse_layers[0].getformat()
-                    layers[key] = layers[key].asformat(sparse_format_l)
-
-        # New uns
-        uns = merge_uns([a.uns for a in all_adatas], uns_merge)
-
-        new_adata = (
-            AnnData(X, obs, var, obsm=obsm, layers=layers, uns=uns)
-            if join == "inner"
-            else AnnData(X, obs, var, obsm=obsm, uns=uns)
-        )
-
-        # raw
-        have_raw = [_adata.raw is not None for _adata in all_adatas]
-        if all(have_raw):
-            new_adata_raw = AnnData.concatenate(
-                *[_adata.raw.to_adata() for _adata in all_adatas],
-                join=join,
-                batch_key=batch_key,
-                batch_categories=batch_categories,
-                index_unique=index_unique,
-            )
-            new_adata.raw = new_adata_raw
-        elif any(have_raw):
-            warnings.warn(
-                "Only some adata objects have `.raw` attribute, "
-                "not concatenating `.raw` attributes.",
-                UserWarning,
-            )
-
-        if not obs.index.is_unique:
-            logger.info("Or pass `index_unique!=None` to `.concatenate`.")
-        return new_adata
 
     def var_names_make_unique(self, join: str = "-"):
         # Important to go through the setter so obsm dataframes are updated too

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1462,6 +1462,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         batch_categories: Sequence[Any] = None,
         uns_merge: Optional[str] = None,
         index_unique: Optional[str] = "-",
+        fill_value=0,
     ) -> "AnnData":
         """\
         Concatenate along the observations axis.
@@ -1495,6 +1496,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             Make the index unique by joining the existing index names with the
             batch category, using `index_unique='-'`, for instance. Provide
             `None` to keep existing indices.
+        fill_value
+            Scalar value to fill newly missing values in arrays with. Note: only applies to arrays
+            and sparse matrices (not dataframes) and will only be used if `join="outer"`.
 
         Returns
         -------
@@ -1645,6 +1649,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             batch_key=batch_key,
             batch_categories=batch_categories,
             uns_merge=uns_merge,
+            fill_value=fill_value,
         )
 
         # Backwards compat, ordering columns:

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -6,7 +6,7 @@ import collections.abc as cabc
 from collections import OrderedDict
 from copy import deepcopy
 from enum import Enum
-from functools import reduce, singledispatch
+from functools import singledispatch
 from pathlib import Path
 from os import PathLike
 from typing import Any, Union, Optional  # Meta
@@ -1684,7 +1684,14 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         if batch_categories is None:
             batch_categories = np.arange(len(all_adatas)).astype(str)
         pat = rf"-({'|'.join(batch_categories)})$"
-        out.var = out.var.iloc[:, out.var.columns.str.extract(pat, expand=False).fillna("").argsort(kind="stable")]
+        out.var = out.var.iloc[
+            :,
+            (
+                out.var.columns.str.extract(pat, expand=False)
+                .fillna("")
+                .argsort(kind="stable")
+            ),
+        ]
 
         return out
 

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1462,7 +1462,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         batch_categories: Sequence[Any] = None,
         uns_merge: Optional[str] = None,
         index_unique: Optional[str] = "-",
-        fill_value=0,
+        fill_value=None,
     ) -> "AnnData":
         """\
         Concatenate along the observations axis.
@@ -1498,7 +1498,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             `None` to keep existing indices.
         fill_value
             Scalar value to fill newly missing values in arrays with. Note: only applies to arrays
-            and sparse matrices (not dataframes) and will only be used if `join="outer"`.
+            and sparse matrices (not dataframes) and will only be used if `join="outer"`. If not
+            provided, the default value is `0` for sparse matrices and `np.nan` for numpy arrays.
 
         Returns
         -------

--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -223,8 +223,15 @@ def gen_reindexer(new_var: pd.Index, cur_var: pd.Index):
     Usage
     -----
 
+    >>> a = AnnData(sparse.eye(3), var=pd.DataFrame(index=list("abc")))
+    >>> b = AnnData(sparse.eye(2), var=pd.DataFrame(index=list("ba")))
     >>> reindexer = gen_reindexer(a.var_names, b.var_names)
-    >>> sparse.vstack([a.X, reindexer(b.X)])
+    >>> sparse.vstack([a.X, reindexer(b.X)]).toarray()
+    array([[1., 0., 0.],
+           [0., 1., 0.],
+           [0., 0., 1.],
+           [0., 1., 0.],
+           [1., 0., 0.]])
     """
     new_size = len(new_var)
     old_size = len(cur_var)

--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -232,14 +232,14 @@ def gen_reindexer(new_var: pd.Index, cur_var: pd.Index, *, fill_value=0):
            [0., 1., 0.],
            [0., 0., 1.],
            [0., 1., 0.],
-           [1., 0., 0.]])
+           [1., 0., 0.]], dtype=float32)
     >>> reindexer_nan = gen_reindexer(a.var_names, b.var_names, fill_value=np.nan)
-    >>> sparse.vstack([a.X, reindexer(b.X)]).toarray()
+    >>> sparse.vstack([a.X, reindexer_nan(b.X)]).toarray()
     array([[ 1.,  0.,  0.],
            [ 0.,  1.,  0.],
            [ 0.,  0.,  1.],
            [ 0.,  1., nan],
-           [ 1.,  0., nan]])
+           [ 1.,  0., nan]], dtype=float32)
     """
     new_size = len(new_var)
     old_size = len(cur_var)

--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -318,13 +318,6 @@ def concat_arrays(arrays, reindexers, index=None, fill_value=None):
         )
 
 
-def concat_aligned_mapping(mappings, reindexers, index=None):
-    return {
-        k: concat_arrays([m[k] for m in mappings], reindexers, index=index)
-        for k in intersect_keys(mappings)
-    }
-
-
 def inner_concat_aligned_mapping(mappings, reindexers=None, index=None):
     result = {}
 

--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from collections.abc import Mapping, MutableSet
 from copy import deepcopy
 from functools import partial, reduce, singledispatch
-from itertools import chain, repeat
+from itertools import repeat
 from operator import and_, or_, sub
 from typing import Callable, Collection, Iterable, TypeVar, Union
 from warnings import warn
@@ -21,6 +21,7 @@ T = TypeVar("T")
 ###################
 # Utilities
 ###################
+
 
 class OrderedSet(MutableSet):
     def __init__(self, vals=()):
@@ -347,7 +348,15 @@ def concat(
     has_raw = [a.raw is not None for a in adatas]
     if all(has_raw):
         raw = concat(
-            [AnnData(X=a.raw.X, obs=pd.DataFrame(index=a.obs_names), var=a.raw.var, varm=a.raw.varm) for a in adatas],
+            [
+                AnnData(
+                    X=a.raw.X,
+                    obs=pd.DataFrame(index=a.obs_names),
+                    var=a.raw.var,
+                    varm=a.raw.varm,
+                )
+                for a in adatas
+            ],
             join=join,
             batch_key=batch_key,
             batch_categories=batch_categories,

--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -376,19 +376,18 @@ def outer_concat(els, new_index: pd.Index, shapes: Collection[int], fill_value=0
 def inner_concat(els, new_index, shapes: Collection[int]):
     """Inner concatenation for obsm"""
     indices = np.split(new_index, np.cumsum(shapes)[:-1])
-    real = list(filter(not_missing, els))
-    min_cols = reduce(min, map(lambda x: x.shape[1], real))
+    min_cols = reduce(min, map(lambda x: x.shape[1], els))
 
-    if all(isinstance(el, pd.DataFrame) for el in real):
+    if all(isinstance(el, pd.DataFrame) for el in els):
         out = pd.concat(els, join="inner")
         out.index = new_index
         return out
-    elif any(isinstance(el, pd.DataFrame) for el in real):
+    elif any(isinstance(el, pd.DataFrame) for el in els):
         raise NotImplementedError(
             "Cannot concatenate a dataframe with other array types."
         )
     # Sparse arrays
-    elif any(isinstance(el, sparse.spmatrix) for el in real):
+    elif any(isinstance(el, sparse.spmatrix) for el in els):
         new_els = []
         for el, index in zip(els, indices):
             result_shape = (len(index), min_cols)

--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -306,10 +306,16 @@ def concat_arrays(arrays, reindexers, index=None, fill_value=None):
         return df
     elif any(isinstance(a, sparse.spmatrix) for a in arrays):
         return sparse.vstack(
-            [f(as_sparse(a), fill_value=fill_value) for f, a in zip(reindexers, arrays)], format="csr"
+            [
+                f(as_sparse(a), fill_value=fill_value)
+                for f, a in zip(reindexers, arrays)
+            ],
+            format="csr",
         )
     else:
-        return np.vstack([f(x, fill_value=fill_value) for f, x in zip(reindexers, arrays)])
+        return np.vstack(
+            [f(x, fill_value=fill_value) for f, x in zip(reindexers, arrays)]
+        )
 
 
 def concat_aligned_mapping(mappings, reindexers, index=None):
@@ -476,7 +482,9 @@ def concat(
         layers = inner_concat_aligned_mapping([a.layers for a in adatas], reindexers)
         obsm = inner_concat_aligned_mapping([a.obsm for a in adatas], index=obs_names)
     elif join == "outer":
-        layers = outer_concat_aligned_mapping([a.layers for a in adatas], reindexers, fill_value=fill_value)
+        layers = outer_concat_aligned_mapping(
+            [a.layers for a in adatas], reindexers, fill_value=fill_value
+        )
         obsm = outer_concat_aligned_mapping(
             [a.obsm for a in adatas], index=obs_names, fill_value=fill_value
         )

--- a/anndata/_io/utils.py
+++ b/anndata/_io/utils.py
@@ -147,7 +147,7 @@ def report_read_key_on_error(func):
     ...     raise NotImplementedError()
     >>> z = zarr.open("tmp.zarr")
     >>> z["X"] = [1, 2, 3]
-    >>> read_arr(z["X"])
+    >>> read_arr(z["X"])  # doctest: +SKIP
     """
 
     @wraps(func)
@@ -179,7 +179,7 @@ def report_write_key_on_error(func):
     ...     raise NotImplementedError()
     >>> z = zarr.open("tmp.zarr")
     >>> X = [1, 2, 3]
-    >>> write_arr(z, "X", X)
+    >>> write_arr(z, "X", X)  # doctest: +SKIP
     """
 
     @wraps(func)

--- a/anndata/compat/_overloaded_dict.py
+++ b/anndata/compat/_overloaded_dict.py
@@ -146,8 +146,8 @@ def _access_warn(key, cur_loc):
 def _adjacency_getter(ovld: OverloadedDict, key, adata: "AnnData"):
     """For overloading:
 
-    >>> mtx = adata.uns["neighbors"]["connectivities"]
-    >>> mtx = adata.uns["neighbors"]["distances"]
+    >>> mtx = adata.uns["neighbors"]["connectivities"]  # doctest: +SKIP
+    >>> mtx = adata.uns["neighbors"]["distances"]  # doctest: +SKIP
     """
     _access_warn(key, f".obsp[{key}]")
     return adata.obsp[key]
@@ -156,8 +156,8 @@ def _adjacency_getter(ovld: OverloadedDict, key, adata: "AnnData"):
 def _adjacency_setter(ovld: OverloadedDict, key, value, adata: "AnnData"):
     """For overloading:
 
-    >>> adata.uns["neighbors"]["connectivities"] = mtx
-    >>> adata.uns["neighbors"]["distances"] = mtx
+    >>> adata.uns["neighbors"]["connectivities"] = mtx  # doctest: +SKIP
+    >>> adata.uns["neighbors"]["distances"] = mtx  # doctest: +SKIP
     """
     _access_warn(key, f".obsp[{key}]")
     adata.obsp[key] = value

--- a/anndata/tests/test_concatenate.py
+++ b/anndata/tests/test_concatenate.py
@@ -135,15 +135,15 @@ def test_concatenate_dense():
 
     X_ref = np.array(
         [
-            [1.0, 2.0, 3.0, 0.0],
-            [4.0, 5.0, 6.0, 0.0],
-            [0.0, 3.0, 2.0, 1.0],
-            [0.0, 6.0, 5.0, 4.0],
-            [0.0, 3.0, 2.0, 1.0],
-            [0.0, 6.0, 5.0, 4.0],
+            [1.0, 2.0, 3.0, np.nan],
+            [4.0, 5.0, 6.0, np.nan],
+            [np.nan, 3.0, 2.0, 1.0],
+            [np.nan, 6.0, 5.0, 4.0],
+            [np.nan, 3.0, 2.0, 1.0],
+            [np.nan, 6.0, 5.0, 4.0],
         ]
     )
-    assert np.array_equal(adata.X, X_ref)
+    np.testing.assert_equal(adata.X, X_ref)
     var_ma = ma.masked_invalid(adata.var.values.tolist())
     var_ma_ref = ma.masked_invalid(
         np.array(

--- a/anndata/tests/test_concatenate.py
+++ b/anndata/tests/test_concatenate.py
@@ -109,7 +109,7 @@ def test_concatenate_dense():
 
 def test_concatenate_layers(array_type, join_type):
     adatas = []
-    for i in range(5):
+    for _ in range(5):
         a = array_type(sparse.random(100, 200, format="csr"))
         adatas.append(AnnData(X=a, layers={"a": a}))
 
@@ -119,7 +119,7 @@ def test_concatenate_layers(array_type, join_type):
 
 def test_concatenate_layers_misaligned(array_type, join_type):
     adatas = []
-    for i in range(5):
+    for _ in range(5):
         a = array_type(sparse.random(100, 200, format="csr"))
         adata = AnnData(X=a, layers={"a": a})
         adatas.append(

--- a/anndata/tests/test_concatenate.py
+++ b/anndata/tests/test_concatenate.py
@@ -183,10 +183,12 @@ def test_concatenate_obsm_inner(obsm_adatas):
 
     assert adata.obsm["df"].columns == ["a"]
     assert adata.obsm["df"]["a"].tolist() == list(range(9))
+    # fmt: off
     true_df = (
         pd.concat([a.obsm["df"] for a in obsm_adatas], join="inner")
         .reset_index(drop=True)
     )
+    # fmt: on
     cur_df = adata.obsm["df"].reset_index(drop=True)
     pd.testing.assert_frame_equal(true_df, cur_df)
 
@@ -218,10 +220,12 @@ def test_concatenate_obsm_outer(obsm_adatas):
         [4, 5, 6, 7],
     ]
 
+    # fmt: off
     true_df = (
         pd.concat([a.obsm["df"] for a in obsm_adatas], join="outer")
         .reset_index(drop=True)
     )
+    # fmt: on
     cur_df = adata.obsm["df"].reset_index(drop=True)
     pd.testing.assert_frame_equal(true_df, cur_df)
 
@@ -433,7 +437,7 @@ def test_concatenate_with_raw():
     with pytest.warns(
         UserWarning,
         match=(
-            "Only some adata objects have `.raw` attribute, "
+            "Only some AnnData objects have `.raw` attribute, "
             "not concatenating `.raw` attributes."
         ),
     ):

--- a/anndata/tests/test_concatenate.py
+++ b/anndata/tests/test_concatenate.py
@@ -77,21 +77,17 @@ def test_concatenate_dense():
     # outer join
     adata = adata1.concatenate(adata2, adata3, join="outer")
 
-    Xma = ma.masked_invalid(adata.X)
-    Xma_ref = ma.masked_invalid(
-        np.array(
-            [
-                [1.0, 2.0, 3.0, np.nan],
-                [4.0, 5.0, 6.0, np.nan],
-                [np.nan, 3.0, 2.0, 1.0],
-                [np.nan, 6.0, 5.0, 4.0],
-                [np.nan, 3.0, 2.0, 1.0],
-                [np.nan, 6.0, 5.0, 4.0],
-            ]
-        )
+    X_ref = np.array(
+        [
+            [1.0, 2.0, 3.0, 0.0],
+            [4.0, 5.0, 6.0, 0.0],
+            [0.0, 3.0, 2.0, 1.0],
+            [0.0, 6.0, 5.0, 4.0],
+            [0.0, 3.0, 2.0, 1.0],
+            [0.0, 6.0, 5.0, 4.0],
+        ]
     )
-    assert np.array_equal(Xma.mask, Xma_ref.mask)
-    assert np.allclose(Xma.compressed(), Xma_ref.compressed())
+    assert np.array_equal(adata.X, X_ref)
     var_ma = ma.masked_invalid(adata.var.values.tolist())
     var_ma_ref = ma.masked_invalid(
         np.array(

--- a/anndata/utils.py
+++ b/anndata/utils.py
@@ -53,14 +53,12 @@ def make_index_unique(index: pd.Index, join: str = "-"):
     Examples
     --------
     >>> from anndata import AnnData
-    >>> adata1 = AnnData(np.ones((3, 2)), dict(obs_names=['a', 'b', 'c']))
-    >>> adata2 = AnnData(np.zeros((3, 2)), dict(obs_names=['d', 'b', 'b']))
-    >>> adata = adata1.concatenate(adata2)
-    >>> adata.obs_names
-    Index(['a', 'b', 'c', 'd', 'b', 'b'], dtype='object')
-    >>> adata.obs_names_make_unique()
-    >>> adata.obs_names
-    Index(['a', 'b', 'c', 'd', 'b-1', 'b-2'], dtype='object')
+    >>> adata = AnnData(np.ones((2, 3)), var=pd.DataFrame(index=["a", "a", "b"]))
+    >>> adata.var_names
+    Index(['a', 'a', 'b'], dtype='object')
+    >>> adata.var_names_make_unique()
+    >>> adata.var_names
+    Index(['a', 'a-1', 'b'], dtype='object')
     """
     if index.is_unique:
         return index

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+addopts = --doctest-modules
 python_files = test_*.py
 testpaths = anndata
 xfail_strict = true


### PR DESCRIPTION
This is a refactor of the `concatenate` method to make it easier to follow and extend, as well as to add some new features.

* Fixes #351 by allowing for concatenation of layers
* Gets us closer to closing #295
* Dataframes in `obsm` keep being dataframes after concatenation
* Categorical columns can keep being categorical after concatenation (basically, pandas rules get followed)

This moves pretty much all of the concatenation logic to the `anndata._core.merge` module, in particular the `concat` function. At some point I would like to deprecate `AnnData.concatenate` and replace it with a `ad.concat`/ `sc.concat` function. There is more work to do before that (most importantly, hammering out the API), but this is a good step forward.

## Breaking change

This was reverted.

~~Currently, there is only one, but I think it's more of a fix really. Previously, an outer join would fill missing values in numpy arrays with `nan`, while sparse arrays would use zeros. This kinda breaks most of what we've been trying to with pretending numpy arrays and scipy sparse arrays are interchangeable.~~

## Performance

This makes outer concatenation significantly faster.

Using this code:

```python
import numpy as np
from anndata.tests.helpers import gen_adata

def permuted_var_adata(nobs, nvar, nvar_kept): 
    adata = gen_adata((nobs, nvar)) 
    return adata[:, np.random.choice(adata.var_names, nvar_kept, replace=False)].copy() 

adatas = [permuted_var_adata(1000, 1000, 900) for i in range(10)]


%timeit adatas[0].concatenate(adatas[1:])
%timeit adatas[0].concatenate(adatas[1:], join="outer")
```

|                          |   inner join |   outer join |
|:-------------------------|-------------:|-------------:|
| master (9e0767b761)      |          240 ms ± 20.5 ms |          1.6 s ± 16 ms |
| current HEAD (0b14e1610) |          237 ms ± 12.4 ms |          304 ms ± 11.2 ms |

## TODO

- [ ] This could probably use a more thorough set of tests. 
- [x] I would also like to deal with the `obsm` issue by making the `join` keyword apply to those entries.
- [x] Black really doesn't like fluent style when it's only two lines. I should make that pretty again.
- [ ] Doc string for concatenate needs to be updated
