### PR TITLE
Fix index_unique argument for concatenating

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1690,6 +1690,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             batch_categories=batch_categories,
             uns_merge=uns_merge,
             fill_value=fill_value,
+            index_unique=index_unique,
         )
 
         # Backwards compat, ordering columns:

--- a/anndata/tests/test_concatenate.py
+++ b/anndata/tests/test_concatenate.py
@@ -46,7 +46,6 @@ def fix_known_differences(orig, result):
     orig = orig.copy()
     result = result.copy()
 
-    result.obs_names = result.obs_names.str.extract(r"^(.*)-\d+$", expand=False)
     result.obs.drop(columns=["batch"], inplace=True)
     result.strings_to_categoricals()  # Should this be implicit in concatenation?
 
@@ -76,7 +75,9 @@ def test_concatenate_roundtrip(join_type, array_type):
         subsets.append(adata[subset_idx])
         remaining = remaining.difference(subset_idx)
 
-    result = subsets[0].concatenate(subsets[1:], join=join_type, uns_merge="same")
+    result = subsets[0].concatenate(
+        subsets[1:], join=join_type, uns_merge="same", index_unique=None
+    )
 
     # Correcting for known differences
     orig, result = fix_known_differences(adata, result)


### PR DESCRIPTION
Looks like I forgot to pass the `index_unique` argument. Also implemented the behaviour of `index_unique=None`, where original `obs_names` are used unmodified.