### PR TITLE
Create parent directory if needed in write_h5ad

### DIFF
--- a/anndata/_io/h5ad.py
+++ b/anndata/_io/h5ad.py
@@ -84,6 +84,10 @@ def write_h5ad(
     mode = "a" if adata.isbacked else "w"
     if adata.isbacked:  # close so that we can reopen below
         adata.file.close()
+    # create directory if it doesn't exist
+    dirname = filepath.parent
+    if not dirname.is_dir():
+        dirname.mkdir(parents=True, exist_ok=True)
     with h5py.File(filepath, mode) as f:
         if "X" in as_dense and isinstance(adata.X, (sparse.spmatrix, SparseDataset)):
             write_sparse_as_dense(f, "X", adata.X, dataset_kwargs=dataset_kwargs)


### PR DESCRIPTION
As opposed to older anndata versions a missing parent directory was not created anymore when write_h5ad was used.