### PR TITLE
Remove circular reference from OverloadedDict

### DIFF
--- a/anndata/compat/_overloaded_dict.py
+++ b/anndata/compat/_overloaded_dict.py
@@ -2,6 +2,7 @@ from collections.abc import MutableMapping
 from functools import partial
 from typing import Any, Callable, Mapping, Optional
 from warnings import warn
+from weakref import proxy
 
 
 class KeyOverload:
@@ -90,7 +91,7 @@ class OverloadedDict(MutableMapping):
         self.data = data
         self.overloaded = overloaded
         for v in overloaded.values():
-            v.parent = self
+            v.parent = proxy(self)
 
     def __getitem__(self, key):
         if key in self.overloaded:


### PR DESCRIPTION
Now `KeyOverload`s only have a proxy reference to the parent `OverloadedDict`. This prevents these objects being managed by the generational garbage collector. That was bad since it could keep large `AnnData` objects in memory. See #360 for more info.

Since there shouldn't be any other references to the `KeyOverload` than from it's parent, I can't think of any problems this could cause.