### PR TITLE
Outer layer concat bugfix

### DIFF
--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -268,11 +268,14 @@ def gen_reindexer(new_var: pd.Index, cur_var: pd.Index, *, fill_value=0):
         else:
             out_dtype = X.dtype
 
-        idxmtx = sparse.coo_matrix(
-            (np.ones(len(new_pts), dtype=int), (cur_pts, new_pts)),
-            shape=(old_size, new_size),
-            dtype=out_dtype,
-        )
+        if X.shape[1] != 0:
+            idxmtx = sparse.coo_matrix(
+                (np.ones(len(new_pts), dtype=int), (cur_pts, new_pts)),
+                shape=(old_size, new_size),
+                dtype=out_dtype,
+            )
+        else:
+            idxmtx = sparse.coo_matrix((0, new_size))
         out = X @ idxmtx
 
         if fill_value != 0:

--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -268,6 +268,8 @@ def gen_reindexer(new_var: pd.Index, cur_var: pd.Index, *, fill_value=0):
         else:
             out_dtype = X.dtype
 
+        # Case where layer was empty
+        # TODO: This could be done more elegantly
         if X.shape[1] != 0:
             idxmtx = sparse.coo_matrix(
                 (np.ones(len(new_pts), dtype=int), (cur_pts, new_pts)),
@@ -279,7 +281,10 @@ def gen_reindexer(new_var: pd.Index, cur_var: pd.Index, *, fill_value=0):
         out = X @ idxmtx
 
         if fill_value != 0:
-            to_fill = new_var.get_indexer(new_var.difference(cur_var))
+            if X.shape[1] != 0:
+                to_fill = new_var.get_indexer(new_var.difference(cur_var))
+            else:
+                to_fill = range(0, len(new_var))
             if len(to_fill) > 0:
                 # More efficient to set columns on csc
                 if sparse.issparse(out):

--- a/anndata/tests/test_concatenate.py
+++ b/anndata/tests/test_concatenate.py
@@ -320,6 +320,21 @@ def test_concatenate_layers_misaligned(array_type, join_type):
     assert_equal(merged.X, merged.layers["a"])
 
 
+def test_concatenate_layers_outer(array_type, fill_val):
+    # Testing that issue #368 is fixed
+    a = AnnData(
+        X=np.ones((10, 20)),
+        layers={"a": array_type(sparse.random(10, 20, format="csr"))},
+    )
+    b = AnnData(X=np.ones((10, 20)))
+
+    c = a.concatenate(b, join="outer", fill_value=fill_val, batch_categories=["a", "b"])
+
+    np.testing.assert_array_equal(
+        asarray(c[c.obs["batch"] == "b"].layers["a"]), fill_val
+    )
+
+
 def test_concatenate_fill_value(fill_val):
     def get_obs_els(adata):
         return {


### PR DESCRIPTION
Fix for #368 

Outer concatenation wouldn't work when a layer was missing.