### PR TITLE
Workaround for large memory usage from using np.ix_ with scipy.sparse

### DIFF
--- a/anndata/_core/index.py
+++ b/anndata/_core/index.py
@@ -118,11 +118,19 @@ def unpack_index(index: Index) -> Tuple[Index1D, Index1D]:
 
 
 @singledispatch
-def _subset(a: Union[np.ndarray, spmatrix, pd.DataFrame], subset_idx: Index):
+def _subset(a: Union[np.ndarray, pd.DataFrame], subset_idx: Index):
     # Select as combination of indexes, not coordinates
     # Correcting for indexing behaviour of np.ndarray
     if all(isinstance(x, cabc.Iterable) for x in subset_idx):
         subset_idx = np.ix_(*subset_idx)
+    return a[subset_idx]
+
+
+@_subset.register(spmatrix)
+def _subset_spmatrix(a: spmatrix, subset_idx: Index):
+    # Correcting for indexing behaviour of sparse.spmatrix
+    if len(subset_idx) > 1 and all(isinstance(x, cabc.Iterable) for x in subset_idx):
+        subset_idx = (subset_idx[0].reshape(-1, 1), *subset_idx[1:])
     return a[subset_idx]
 
 


### PR DESCRIPTION
Fixes #380

Basically, `scipy.sparse` has weird memory usage behavior around orthogonal indexing:

```python
from scipy import sparse
import numpy as np

s = sparse.random(10000, 10000, format="csr")
idx1 = np.random.choice(10000, 1000, replace=False)
idx2 = np.random.choice(10000, 1000, replace=False)

# This is fine
%memit s[idx1.reshape(-1, 1), idx2]
# peak memory: 102.25 MiB, increment: 1.36 MiB

# This is not
%memit s[idx1.reshape(-1, 1), idx2.reshape(1, -1)]
# peak memory: 126.00 MiB, increment: 23.38 MiB  # Increases with size of subset
```

Though the latter is what you're supposed to pass to `np.ndarrays`.