### PR TITLE
Subset colors bugfix

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -4,7 +4,7 @@ Main class and helper functions.
 import warnings
 import collections.abc as cabc
 from collections import OrderedDict
-from copy import deepcopy
+from copy import copy, deepcopy
 from enum import Enum
 from functools import singledispatch
 from pathlib import Path
@@ -351,7 +351,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         self._varp = adata_ref.varp._view(self, vidx)
         # Speical case for old neighbors, backwards compat. Remove in anndata 0.8.
         uns_new = _slice_uns_sparse_matrices(
-            adata_ref._uns, self._oidx, adata_ref.n_obs
+            copy(adata_ref._uns), self._oidx, adata_ref.n_obs
         )
         # fix categories
         self._remove_unused_categories(adata_ref.obs, obs_sub, uns_new)

--- a/anndata/tests/test_uns.py
+++ b/anndata/tests/test_uns.py
@@ -22,7 +22,10 @@ def test_uns_color_subset():
     assert "cat2_colors" not in v.uns
 
     # Otherwise the colors should still match after reseting
-    adata.uns["cat1_colors"] = ["red", "green", "blue", "yellow"]
+    cat1_colors = ["red", "green", "blue", "yellow"]
+    adata.uns["cat1_colors"] = cat1_colors.copy()
     v = adata[[0, 1], :]
     assert len(v.uns["cat1_colors"]) == 1
     assert v.uns["cat1_colors"][0] == "red"
+    # But original object should not change
+    assert list(adata.uns["cat1_colors"]) == cat1_colors


### PR DESCRIPTION
Fixes #387 and https://github.com/theislab/scanpy/issues/1134

This makes a shallow copy of uns whenever a subset is made, so the changes to colors don't propagate to the parent.