### PR TITLE
Allow passing a sparse dataframe for X

### DIFF
--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -66,6 +66,17 @@ def test_create_from_df():
     assert df.index.tolist() == ad.obs_names.tolist()
 
 
+def test_create_from_sparse_df():
+    s = sp.random(20, 30, density=0.2)
+    obs_names = [f"obs{i}" for i in range(20)]
+    var_names = [f"var{i}" for i in range(30)]
+    df = pd.DataFrame.sparse.from_spmatrix(s, index=obs_names, columns=var_names)
+    a = AnnData(df)
+    b = AnnData(s, obs=pd.DataFrame(index=obs_names), var=pd.DataFrame(index=var_names))
+    assert_equal(a, b)
+    assert issparse(a.X)
+
+
 def test_create_from_df_with_obs_and_var():
     df = pd.DataFrame(np.ones((3, 2)), index=["a", "b", "c"], columns=["A", "B"])
     obs = pd.DataFrame(np.ones((3, 1)), index=df.index, columns=["C"])

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -11,6 +11,10 @@ On master
 - The types of :attr:`~anndata.AnnData.raw`, :attr:`~anndata.AnnData.layers`, :attr:`~anndata.AnnData.obsm`,
   :attr:`~anndata.AnnData.varm`, :attr:`~anndata.AnnData.obsp` and :attr:`~anndata.AnnData.varp` will be exported.
 
+.. rubric:: Functionality
+
+- AnnData object created from dataframes with sparse values will have sparse `.X` :pr:`395` :smaller:`I Virshup`
+
 .. rubric:: Bug fixes
 
 - Fixed error from `AnnData.concatenate` by bumping minimum versions of numpy and pandas :issue:`385`


### PR DESCRIPTION
Fixes #394.

Allows passing a `pd.DataFrame` with `SparseDtype` columns as `X` resulting in sparse array in `X` .