### PR TITLE
Fix documentation of argument types for anndata.concat

### DIFF
--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -6,7 +6,8 @@ from collections.abc import Mapping, MutableSet
 from functools import reduce, singledispatch
 from itertools import repeat
 from operator import and_, or_, sub
-from typing import Callable, Collection, Iterable, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Collection, Iterable, Optional, Tuple, TypeVar, Union
+import typing
 from warnings import warn
 
 import numpy as np
@@ -571,7 +572,7 @@ def dim_size(adata, *, axis=None, dim=None):
 
 
 def concat(
-    adatas: Union[Collection[AnnData], "Mapping[str, AnnData]"],
+    adatas: Union[Collection[AnnData], "typing.Mapping[str, AnnData]"],
     *,
     axis: Literal[0, 1] = 0,
     join: Literal["inner", "outer"] = "inner",
@@ -580,7 +581,7 @@ def concat(
     label: Optional[str] = None,
     keys: Optional[Collection] = None,
     index_unique: Optional[str] = None,
-    fill_value: Optional = None,
+    fill_value: Optional[Any] = None,
     pairwise: bool = False,
 ) -> AnnData:
     """Concatenates AnnData objects along an axis.


### PR DESCRIPTION
Types were previously not showing up.

This was due to sphinx_autodoc_typehints failing to process `Optional` and `collections.Mapping[str, AnnData]` as valid typehints (since they are not). However, instead of creating any warning or error, this just silently passed and did nothing.