### PR TITLE
[WIP] Make obsm/varm creation lazy

### DIFF
--- a/anndata/_core/aligned_mapping.py
+++ b/anndata/_core/aligned_mapping.py
@@ -232,8 +232,8 @@ class AxisArrays(AlignedActualMixin, AxisArraysBase):
             self.update(vals)
 
     def __setitem__(self, key: str, value: V):
-        if self._axis == 0:
-            self.parent._obsm[key] = value#.copy()
+        if self._axis == 0 and isinstance(self.parent, anndata.AnnData):
+            self.parent._obsm[key] = value
         super(AxisArrays, self).__setitem__(key, value)
 
 

--- a/anndata/_core/aligned_mapping.py
+++ b/anndata/_core/aligned_mapping.py
@@ -243,6 +243,17 @@ class AxisArrays(AlignedActualMixin, AxisArraysBase):
         if parent_needs_update:
             self.parent._obsm[key] = value
 
+    def __delitem__(self, key: str):
+        parent_needs_update = (
+            self._axis == 0
+            and isinstance(self.parent, anndata.AnnData)
+            and self._parent_needs_update
+        )
+        super(AxisArrays, self).__delitem__(key)
+        if parent_needs_update:
+            self.parent._obsm.pop(key)
+
+
 
 class AxisArraysView(AlignedViewMixin, AxisArraysBase):
     def __init__(

--- a/anndata/_core/aligned_mapping.py
+++ b/anndata/_core/aligned_mapping.py
@@ -231,27 +231,23 @@ class AxisArrays(AlignedActualMixin, AxisArraysBase):
         self._data = dict()
         if vals is not None:
             self.update(vals)
-        self._parent_needs_update = True
+        self._parent_needs_update = isinstance(self.parent, anndata.AnnData)
+
+    @property
+    def _parent_data(self):
+        if self._axis == 0:
+            return self._parent._obsm
+        return self._parent._varm
 
     def __setitem__(self, key: str, value: V):
-        parent_needs_update = (
-            self._axis == 0
-            and isinstance(self.parent, anndata.AnnData)
-            and self._parent_needs_update
-        )
         super(AxisArrays, self).__setitem__(key, value)
-        if parent_needs_update:
-            self.parent._obsm[key] = value
+        if self._parent_needs_update:
+            self._parent_data[key] = value
 
     def __delitem__(self, key: str):
-        parent_needs_update = (
-            self._axis == 0
-            and isinstance(self.parent, anndata.AnnData)
-            and self._parent_needs_update
-        )
         super(AxisArrays, self).__delitem__(key)
-        if parent_needs_update:
-            self.parent._obsm.pop(key)
+        if self._parent_needs_update:
+            self._parent_data.pop(key)
 
 
 class AxisArraysView(AlignedViewMixin, AxisArraysBase):

--- a/anndata/_core/aligned_mapping.py
+++ b/anndata/_core/aligned_mapping.py
@@ -231,6 +231,11 @@ class AxisArrays(AlignedActualMixin, AxisArraysBase):
         if vals is not None:
             self.update(vals)
 
+    def __setitem__(self, key: str, value: V):
+        if self._axis == 0:
+            self.parent._obsm[key] = value#.copy()
+        super(AxisArrays, self).__setitem__(key, value)
+
 
 class AxisArraysView(AlignedViewMixin, AxisArraysBase):
     def __init__(

--- a/anndata/_core/aligned_mapping.py
+++ b/anndata/_core/aligned_mapping.py
@@ -239,9 +239,9 @@ class AxisArrays(AlignedActualMixin, AxisArraysBase):
             and isinstance(self.parent, anndata.AnnData)
             and self._parent_needs_update
         )
+        super(AxisArrays, self).__setitem__(key, value)
         if parent_needs_update:
             self.parent._obsm[key] = value
-        super(AxisArrays, self).__setitem__(key, value)
 
 
 class AxisArraysView(AlignedViewMixin, AxisArraysBase):

--- a/anndata/_core/aligned_mapping.py
+++ b/anndata/_core/aligned_mapping.py
@@ -254,7 +254,6 @@ class AxisArrays(AlignedActualMixin, AxisArraysBase):
             self.parent._obsm.pop(key)
 
 
-
 class AxisArraysView(AlignedViewMixin, AxisArraysBase):
     def __init__(
         self,

--- a/anndata/_core/aligned_mapping.py
+++ b/anndata/_core/aligned_mapping.py
@@ -223,6 +223,7 @@ class AxisArrays(AlignedActualMixin, AxisArraysBase):
         vals: Union[Mapping, AxisArraysBase, None] = None,
     ):
         self._parent = parent
+        self._parent_needs_update = False
         if axis not in (0, 1):
             raise ValueError()
         self._axis = axis
@@ -230,9 +231,15 @@ class AxisArrays(AlignedActualMixin, AxisArraysBase):
         self._data = dict()
         if vals is not None:
             self.update(vals)
+        self._parent_needs_update = True
 
     def __setitem__(self, key: str, value: V):
-        if self._axis == 0 and isinstance(self.parent, anndata.AnnData):
+        parent_needs_update = (
+            self._axis == 0
+            and isinstance(self.parent, anndata.AnnData)
+            and self._parent_needs_update
+        )
+        if parent_needs_update:
             self.parent._obsm[key] = value
         super(AxisArrays, self).__setitem__(key, value)
 

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1453,7 +1453,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 uns=self._uns.copy()
                 if isinstance(self.uns, DictView)
                 else deepcopy(self._uns),
-                obsm=self.obsm.copy(),
+                obsm={k: v.copy() for k, v in self._obsm.items()},
                 varm=self.varm.copy(),
                 obsp=self.obsp.copy(),
                 varp=self.varp.copy(),

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -506,7 +506,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         self.uns = uns or OrderedDict()
 
         # TODO: Think about consequences of making obsm a group in hdf
-        self._obsm = AxisArrays(self, 0, vals=convert_to_dict(obsm))
+        self._obsm = convert_to_dict(obsm)
         self._varm = AxisArrays(self, 1, vals=convert_to_dict(varm))
 
         self._obsp = PairwiseArrays(self, 0, vals=convert_to_dict(obsp))

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -904,11 +904,15 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         of length `n_obs`.
         Is sliced with `data` and `obs` but behaves otherwise like a :term:`mapping`.
         """
-        return self._obsm
+        if self.is_view:
+            obsm = AxisArrays(self._adata_ref, 0, self._obsm)
+            return obsm._view(self, self.obs_names)
+        else:
+            return AxisArrays(self, 0, self._obsm)
 
     @obsm.setter
     def obsm(self, value):
-        obsm = AxisArrays(self, 0, vals=convert_to_dict(value))
+        obsm = convert_to_dict(value)
         if self.is_view:
             self._init_as_actual(self.copy())
         self._obsm = obsm

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -905,10 +905,11 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         Is sliced with `data` and `obs` but behaves otherwise like a :term:`mapping`.
         """
         if self.is_view:
-            obsm = AxisArrays(self._adata_ref, 0, self._obsm)
+            obsm = AxisArrays(self._adata_ref, 0, self._adata_ref._obsm)
             idx = self._oidx
             if isinstance(idx, slice):
-                idx = self.obs_names.isin(self.obs_names[idx])
+                idx = self._adata_ref.obs_names[idx]
+                idx = self._adata_ref.obs_names.isin(idx)
             return obsm._view(self, idx)
         else:
             return AxisArrays(self, 0, self._obsm)

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -820,7 +820,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         if self.is_view:
             self._init_as_actual(self.copy())
         getattr(self, attr).index = value
-        for v in getattr(self, f"{attr}m").values():
+        for v in getattr(self, f"_{attr}m").values():
             if isinstance(v, pd.DataFrame):
                 v.index = value
 
@@ -906,7 +906,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         """
         if self.is_view:
             obsm = AxisArrays(self._adata_ref, 0, self._obsm)
-            return obsm._view(self, self.obs_names)
+            idx = self._oidx
+            if isinstance(idx, slice):
+                idx = self.obs_names.isin(self.obs_names[idx])
+            return obsm._view(self, idx)
         else:
             return AxisArrays(self, 0, self._obsm)
 

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -917,6 +917,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
     @obsm.setter
     def obsm(self, value):
         obsm = convert_to_dict(value)
+        obsm = convert_to_dict(AxisArrays(self, 0, obsm))
         if self.is_view:
             self._init_as_actual(self.copy())
         self._obsm = obsm

--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -484,10 +484,13 @@ def gen_outer_reindexers(els, shapes, new_index: pd.Index, *, axis=0):
 
 
 def outer_concat_aligned_mapping(
-    mappings, reindexers=None, index=None, fill_value=None, axis=0
+    mappings, reindexers=None, index=None, fill_value=None, axis=0, shapes=None,
 ):
     result = {}
-    ns = [m.parent.shape[axis] for m in mappings]
+
+    ns = shapes
+    if not ns:
+        ns = [m.parent.shape[axis] for m in mappings]
 
     for k in union_keys(mappings):
         els = [m.get(k, MissingVal) for m in mappings]
@@ -824,7 +827,7 @@ def concat(
             [a.layers for a in adatas], axis=axis, reindexers=reindexers
         )
         concat_mapping = inner_concat_aligned_mapping(
-            [getattr(a, f"{dim}m") for a in adatas], index=concat_indices
+            [getattr(a, f"_{dim}m") for a in adatas], index=concat_indices
         )
         if pairwise:
             concat_pairwise = concat_pairwise_mapping(
@@ -839,8 +842,9 @@ def concat(
             [a.layers for a in adatas], reindexers, axis=axis, fill_value=fill_value
         )
         concat_mapping = outer_concat_aligned_mapping(
-            [getattr(a, f"{dim}m") for a in adatas],
+            [getattr(a, f"_{dim}m") for a in adatas],
             index=concat_indices,
+            shapes=[a.shape[axis] for a in adatas],
             fill_value=fill_value,
         )
         if pairwise:

--- a/anndata/_core/raw.py
+++ b/anndata/_core/raw.py
@@ -29,11 +29,11 @@ class Raw:
         if adata.isbacked == (X is None):
             self._X = X
             self._var = _gen_dataframe(var, self.X.shape[1], ["var_names"])
-            self._varm = AxisArrays(self, 1, varm)
+            self._varm = varm
         elif X is None:  # construct from adata
             self._X = adata.X.copy()
             self._var = adata.var.copy()
-            self._varm = AxisArrays(self, 1, adata.varm.copy())
+            self._varm = adata._varm.copy()
         elif adata.isbacked:
             raise ValueError("Cannot specify X if adata is backed")
 
@@ -87,7 +87,7 @@ class Raw:
 
     @property
     def varm(self):
-        return self._varm
+        return AxisArrays(self, 1, self._varm)
 
     @property
     def var_names(self):
@@ -115,7 +115,7 @@ class Raw:
         new = Raw(self._adata, X=X, var=var)
         if self._varm is not None:
             # Since there is no view of raws
-            new._varm = self._varm._view(_RawViewHack(self, vidx), (vidx,)).copy()
+            new._varm = self.varm._view(_RawViewHack(self, vidx), (vidx,)).copy()
         return new
 
     def __str__(self):

--- a/anndata/_io/write.py
+++ b/anndata/_io/write.py
@@ -41,8 +41,8 @@ def write_csvs(
     d = dict(
         obs=adata._obs,
         var=adata._var,
-        obsm=adata._obsm.to_df(),
-        varm=adata._varm.to_df(),
+        obsm=adata.obsm.to_df(),
+        varm=adata.varm.to_df(),
     )
     if not skip_data:
         d["X"] = pd.DataFrame(adata._X.toarray() if issparse(adata._X) else adata._X)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,46 +1,6 @@
-[tool.poetry]
-name = "anndata"
-version = "0.7.1"
-description = ""
-authors = ["Your Name <you@example.com>"]
-
-[tool.poetry.dependencies]
-python = "^3.8"
-pandas = "^1.0.3"
-numpy = "^1.18.3"
-scipy = "^1.4.1"
-h5py = "^2.10.0"
-natsort = "^7.0.1"
-packaging = "^20.3"
-objgraph = "^3.4.1"
-setuptools_scm = "^4.1.2"
-pytoml = "^0.1.21"
-
-[tool.poetry.dev-dependencies]
-loompy = ">=3.0.5"
-pytest = ">=3.9"
-pytest-cov = "^2.8.1"
-codacy-coverage = "^1.3.11"
-zarr = "^2.4.0"
-sklearn = "^0.0"
-xlrd = "^1.2.0"
-joblib = "^0.14.1"
-black = "^19.10b0"
-boltons = "^20.1.0"
-pytest-xdist = "^1.31.0"
-ipykernel = "^5.2.1"
-pympler = "^0.8"
-matplotlib = "^3.2.1"
-memory_profiler = "^0.57.0"
-pylint = "^2.5.3"
-mypy = "^0.782"
-pydocstyle = "^5.0.2"
-
-[tool.pytest.ini_options]
-addopts = '--doctest-modules'
-python_files = 'test_*.py'
-testpaths = ['anndata', 'docs/concatenation.rst']
-xfail_strict = true
+[build-system]
+requires = ['setuptools', 'setuptools_scm', 'wheel']
+build-backend = 'setuptools.build_meta'
 
 [tool.black]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,46 @@
-[build-system]
-requires = ['setuptools', 'setuptools_scm', 'wheel']
-build-backend = 'setuptools.build_meta'
+[tool.poetry]
+name = "anndata"
+version = "0.7.1"
+description = ""
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+pandas = "^1.0.3"
+numpy = "^1.18.3"
+scipy = "^1.4.1"
+h5py = "^2.10.0"
+natsort = "^7.0.1"
+packaging = "^20.3"
+objgraph = "^3.4.1"
+setuptools_scm = "^4.1.2"
+pytoml = "^0.1.21"
+
+[tool.poetry.dev-dependencies]
+loompy = ">=3.0.5"
+pytest = ">=3.9"
+pytest-cov = "^2.8.1"
+codacy-coverage = "^1.3.11"
+zarr = "^2.4.0"
+sklearn = "^0.0"
+xlrd = "^1.2.0"
+joblib = "^0.14.1"
+black = "^19.10b0"
+boltons = "^20.1.0"
+pytest-xdist = "^1.31.0"
+ipykernel = "^5.2.1"
+pympler = "^0.8"
+matplotlib = "^3.2.1"
+memory_profiler = "^0.57.0"
+pylint = "^2.5.3"
+mypy = "^0.782"
+pydocstyle = "^5.0.2"
+
+[tool.pytest.ini_options]
+addopts = '--doctest-modules'
+python_files = 'test_*.py'
+testpaths = ['anndata', 'docs/concatenation.rst']
+xfail_strict = true
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
Makes `AxisArrays` creation for `obsm` and `varm` lazy, meaning only create these objects if needed and no reference inside the `AnnData` object is needed.

This should fixes the increased memory consumption when creating multiple `AnnData` objects.

Should fix #360 and was proposed here https://github.com/theislab/anndata/pull/363#issuecomment-624367298