### PR TITLE
QOL improvements for overloaded dict

### DIFF
--- a/anndata/compat/_overloaded_dict.py
+++ b/anndata/compat/_overloaded_dict.py
@@ -1,6 +1,6 @@
 from collections.abc import MutableMapping
 from functools import partial
-from typing import Any, Callable, Mapping, Optional
+from typing import Any, Callable, List, Mapping, Optional
 from warnings import warn
 from weakref import proxy
 
@@ -128,6 +128,12 @@ class OverloadedDict(MutableMapping):
 
     def copy(self) -> dict:
         return self.data.copy()
+
+    def keys(self):
+        return self.data.keys()
+
+    def _ipython_key_completions_(self) -> List[str]:
+        return list(self.keys())
 
 
 #######################################

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -1,6 +1,13 @@
 .. role:: small
 .. role:: smaller
 
+On master
+~~~~~~~~~
+
+.. rubric:: Functionality
+
+- Added ipython tab completion and a useful return from `.keys` to `adata.uns` :pr:`415` :smaller:`I Virshup`
+
 0.7.4 :small:`2020-07-10`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
* Added ipython tab completion
* `.keys()` returns underlying data's keys, so you can see what the keys actually are.