### PR TITLE
Fix categoricals/ string arrays being read as bytes in h5py>=3

### DIFF
--- a/anndata/_io/h5ad.py
+++ b/anndata/_io/h5ad.py
@@ -549,9 +549,9 @@ def read_group(group: h5py.Group) -> Union[dict, pd.DataFrame, sparse.spmatrix]:
 @read_attribute.register(h5py.Dataset)
 @report_read_key_on_error
 def read_dataset(dataset: h5py.Dataset):
-    if h5py.check_string_dtype(dataset.dtype):
+    if H5PY_V3:
         string_dtype = h5py.check_string_dtype(dataset.dtype)
-        if H5PY_V3 and string_dtype.encoding == "utf-8":
+        if (string_dtype is not None) and (string_dtype.encoding == "utf-8"):
             dataset = dataset.asstr()
     value = dataset[()]
     if not hasattr(value, "dtype"):

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -8,6 +8,10 @@ On master
 
 - Added ipython tab completion and a useful return from `.keys` to `adata.uns` :pr:`415` :smaller:`I Virshup`
 
+.. rubric:: Bug fixes
+
+- Compatibility with `h5py>=3` strings :pr:`444` :smaller:`I Virshup`
+
 0.7.4 :small:`2020-07-10`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fixes #442

TODO:

- [x] ~~Add test cases written with pre 3.0 h5py~~
  - after more investigation, I don't think there should be any change in how data get's written. Just how it's read.
- [x] Figure out how to convert structured arrays with strings in them.