### PR TITLE
Add type checks for dataframe column names at write time

### DIFF
--- a/anndata/_io/utils.py
+++ b/anndata/_io/utils.py
@@ -3,8 +3,13 @@ from functools import wraps, singledispatch
 from warnings import warn
 
 from packaging import version
+import h5py
 
 from .._core.sparse_dataset import SparseDataset
+
+# For allowing h5py v3
+# https://github.com/theislab/anndata/issues/442
+H5PY_V3 = version.parse(h5py.__version__).major >= 3
 
 # -------------------------------------------------------------------------------
 # Type conversion
@@ -86,6 +91,22 @@ def convert_string(string):
         return None
     else:
         return string
+
+
+def check_key(key):
+    """Checks that passed value is a valid h5py key.
+
+    Should convert it if there is an obvious conversion path, error otherwise.
+    """
+    typ = type(key)
+    if issubclass(typ, str):
+        return str(key)
+    # TODO: Should I try to decode bytes? It's what h5py would do,
+    # but it will be read out as a str.
+    # elif issubclass(typ, bytes):
+    # return key
+    else:
+        raise TypeError(f"{key} of type {typ} is an invalid key. Should be str.")
 
 
 # -------------------------------------------------------------------------------

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -447,6 +447,27 @@ def test_write_large_categorical(tmp_path, diskfmt):
     assert_equal(orig, curr)
 
 
+def test_write_string_types(tmp_path, diskfmt):
+    adata_pth = tmp_path / f"adata.{diskfmt}"
+
+    adata = ad.AnnData(
+        np.ones((3, 3)),
+        obs=pd.DataFrame(
+            np.ones((3, 2)),
+            columns=["a", np.str_("b")],
+            index=["a", "b", "c"],
+        ),
+    )
+
+    write = getattr(adata, f"write_{diskfmt}")
+    read = getattr(ad, f"read_{diskfmt}")
+
+    write(adata_pth)
+    from_disk = read(adata_pth)
+
+    assert_equal(adata, from_disk)
+
+
 def test_zarr_chunk_X(tmp_path):
     import zarr
 

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -448,6 +448,7 @@ def test_write_large_categorical(tmp_path, diskfmt):
 
 
 def test_write_string_types(tmp_path, diskfmt):
+    # https://github.com/theislab/anndata/issues/456
     adata_pth = tmp_path / f"adata.{diskfmt}"
 
     adata = ad.AnnData(
@@ -466,6 +467,11 @@ def test_write_string_types(tmp_path, diskfmt):
     from_disk = read(adata_pth)
 
     assert_equal(adata, from_disk)
+
+    adata.obs[b"c"] = np.zeros(3)
+    # This should error, and tell you which key is at fault
+    with pytest.raises(TypeError, match=str(b"c")):
+        write(adata_pth)
 
 
 def test_zarr_chunk_X(tmp_path):

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -1,6 +1,13 @@
 .. role:: small
 .. role:: smaller
 
+On master
+~~~~~~~~~
+
+.. rubric:: Bug fixes
+
+- Fixed bug where `np.str_` column names errored at write time :pr:`457` :smaller:`I Virshup`
+
 0.7.5 :small:`2020-11-12`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ scipy~=1.0
 h5py
 natsort
 importlib_metadata>=0.7; python_version < '3.8'
-packaging
+packaging>=20


### PR DESCRIPTION
Fixes #456

I've added checks for the types of column names. Previously we had just been relying on h5py throwing an error about this, but now h5py errors if the column name is an `np.str_`.

I'm not sure this is a complete solution. If `bytes` are passed as an element name, or as attributes in h5py (at least in v3) they will read back as `str`. What are we supposed to do here? To my mind, all text data should be `str`, and raw bytes are `bytes`. h5py is making the assumption that passed `bytes` objects are text data.

Do we go with the h5py assumption that `bytes` are text data? We implicitly followed this before, but now this can require extra handling (if some columns are `str` and some are `bytes`, we have to normalize elements to one type before we can write them https://github.com/h5py/h5py/issues/1763, though this may be a bug).

I think to be safe, we would throw an error if someone tries to use bytes as a key, since it will be (and has been in the past, I think) returned as a string. However, this is a behavior change, and I have no idea how many people it would affect. My hope is that it's few.