### PR TITLE
Allow `del adata.X`, `adata.X = None`

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -627,7 +627,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
     def X(self, value: Optional[Union[np.ndarray, sparse.spmatrix]]):
         if value is None:
             if self.isbacked:
-                raise ValueError("Cannot currently remove data matrix from backed object.")
+                raise ValueError(
+                    "Cannot currently remove data matrix from backed object."
+                )
             if self.is_view:
                 self._init_as_actual(self.copy())
             self._X = None

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1280,6 +1280,11 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             else:
                 return m.T
 
+        if X is not None:
+            dtype = X.dtype
+        else:
+            dtype = "float32"
+
         return AnnData(
             t_csr(X),
             obs=self.var,
@@ -1292,7 +1297,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             varp=self.obsp.copy(),
             filename=self.filename,
             layers={k: t_csr(v) for k, v in self.layers.items()},
-            dtype=self.X.dtype.name # problem: X might be none so dtype might not be available
+            dtype=dtype,
         )
 
     T = property(transpose)

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -627,7 +627,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
     def X(self, value: Optional[Union[np.ndarray, sparse.spmatrix]]):
         if value is None:
             if self.isbacked:
-                raise ValueError(
+                raise NotImplementedError(
                     "Cannot currently remove data matrix from backed object."
                 )
             if self.is_view:

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -625,11 +625,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
     @X.setter
     def X(self, value: Optional[Union[np.ndarray, sparse.spmatrix]]):
-        if not isinstance(value, StorageType.classes()) and not np.isscalar(value):
-            if hasattr(value, "to_numpy") and hasattr(value, "dtypes"):
-                value = ensure_df_homogeneous(value, "X")
-            else:  # TODO: asarray? asanyarray?
-                value = np.array(value)
         if value is None:
             if self.is_view:
                 raise ValueError(
@@ -639,6 +634,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 raise ValueError("Not implemented.")
             self._X = None
             return
+        if not isinstance(value, StorageType.classes()) and not np.isscalar(value):
+            if hasattr(value, "to_numpy") and hasattr(value, "dtypes"):
+                value = ensure_df_homogeneous(value, "X")
+            else:  # TODO: asarray? asanyarray?
+                value = np.array(value)
+
         # If indices are both arrays, we need to modify them
         # so we don’t set values like coordinates
         # This can occur if there are succesive views

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -626,10 +626,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
     @X.setter
     def X(self, value: Optional[Union[np.ndarray, sparse.spmatrix]]):
         if value is None:
-            if self.is_view:
-                self._init_as_actual(self.copy())
             if self.isbacked:
                 raise ValueError("Not implemented.")
+            if self.is_view:
+                self._init_as_actual(self.copy())
             self._X = None
             return
         if not isinstance(value, StorageType.classes()) and not np.isscalar(value):

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1273,20 +1273,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             )
 
         def t_csr(m: sparse.spmatrix) -> sparse.csr_matrix:
-            if m is None:
-                return None
-            elif sparse.isspmatrix_csr(m):
-                return m.T.tocsr()
-            else:
-                return m.T
-
-        if X is not None:
-            dtype = X.dtype
-        else:
-            dtype = "float32"
+            return m.T.tocsr() if sparse.isspmatrix_csr(m) else m.T
 
         return AnnData(
-            t_csr(X),
+            X=t_csr(X) if X is not None else None,
             obs=self.var,
             var=self.obs,
             # we're taking a private attributes here to be able to modify uns of the original object
@@ -1297,7 +1287,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             varp=self.obsp.copy(),
             filename=self.filename,
             layers={k: t_csr(v) for k, v in self.layers.items()},
-            dtype=dtype,
+            dtype=self.X.dtype.name if X is not None else "float32",
         )
 
     T = property(transpose)

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -684,6 +684,10 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 f"need to be {self.shape}."
             )
 
+    @X.deleter
+    def X(self):
+        self.X = None
+
     @property
     def layers(self) -> Union[Layers, LayersView]:
         """\

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -627,9 +627,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
     def X(self, value: Optional[Union[np.ndarray, sparse.spmatrix]]):
         if value is None:
             if self.is_view:
-                raise ValueError(
-                    "Copy the view before setting the data matrix to `None`."
-                )
+                self._init_as_actual(self.copy())
             if self.isbacked:
                 raise ValueError("Not implemented.")
             self._X = None

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1273,7 +1273,12 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             )
 
         def t_csr(m: sparse.spmatrix) -> sparse.csr_matrix:
-            return m.T.tocsr() if sparse.isspmatrix_csr(m) else m.T
+            if m is None:
+                return None
+            elif sparse.isspmatrix_csr(m):
+                return m.T.tocsr()
+            else:
+                return m.T
 
         return AnnData(
             t_csr(X),
@@ -1287,7 +1292,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             varp=self.obsp.copy(),
             filename=self.filename,
             layers={k: t_csr(v) for k, v in self.layers.items()},
-            dtype=self.X.dtype.name,
+            dtype=self.X.dtype.name # problem: X might be none so dtype might not be available
         )
 
     T = property(transpose)

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -627,7 +627,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
     def X(self, value: Optional[Union[np.ndarray, sparse.spmatrix]]):
         if value is None:
             if self.isbacked:
-                raise ValueError("Not implemented.")
+                raise ValueError("Cannot currently remove data matrix from backed object.")
             if self.is_view:
                 self._init_as_actual(self.copy())
             self._X = None

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -118,15 +118,6 @@ def test_attr_deletion():
     assert_equal(full, empty, exact=True)
 
 
-def test_not_view_after_deletion():
-    full = gen_adata((30, 30))
-    for attr in ["X", "obs", "var", "obsm", "varm", "obsp", "varp", "layers", "uns"]:
-        view = full[:, :20]
-        assert view.is_view
-        delattr(view, attr)
-        assert not view.is_view
-
-
 def test_names():
     adata = AnnData(
         np.array([[1, 2, 3], [4, 5, 6]]),

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -118,6 +118,15 @@ def test_attr_deletion():
     assert_equal(full, empty, exact=True)
 
 
+def test_not_view_after_deletion():
+    full = gen_adata((30, 30))
+    for attr in ["X", "obs", "var", "obsm", "varm", "obsp", "varp", "layers", "uns"]:
+        view = full[:, :20]
+        assert view.is_view
+        delattr(view, attr)
+        assert not view.is_view
+
+
 def test_names():
     adata = AnnData(
         np.array([[1, 2, 3], [4, 5, 6]]),

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -111,8 +111,8 @@ def test_df_warnings():
 def test_attr_deletion():
     full = gen_adata((30, 30))
     # Empty has just X, obs_names, var_names
-    empty = AnnData(full.X, obs=full.obs[[]], var=full.var[[]])
-    for attr in ["obs", "var", "obsm", "varm", "obsp", "varp", "layers", "uns"]:
+    empty = AnnData(None, obs=full.obs[[]], var=full.var[[]])
+    for attr in ["X", "obs", "var", "obsm", "varm", "obsp", "varp", "layers", "uns"]:
         delattr(full, attr)
         assert_equal(getattr(full, attr), getattr(empty, attr))
     assert_equal(full, empty, exact=True)
@@ -586,4 +586,10 @@ def test_copy():
 def test_delete_X():
     adata = AnnData(np.array([[1, 2, 3], [4, 5, 6]]), dict(o1=[1, 2], o2=[3, 4]))
     adata.X = None
+    assert adata.X is None
+
+    adata.X = np.array([[4, 5, 6], [1, 2, 3]])
+    assert adata.X is not None
+
+    del adata.X
     assert adata.X is None

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -583,13 +583,23 @@ def test_copy():
             assert_eq_not_id(map_sprs[key], map_copy[key])
 
 
-def test_delete_X():
+def test_x_is_none():
+    # test setter and getter
     adata = AnnData(np.array([[1, 2, 3], [4, 5, 6]]), dict(o1=[1, 2], o2=[3, 4]))
     adata.X = None
     assert adata.X is None
-
+    
+    # test setter and deleter
     adata.X = np.array([[4, 5, 6], [1, 2, 3]])
     assert adata.X is not None
-
     del adata.X
     assert adata.X is None
+    
+    # test initialiser
+    shape = (3, 5)
+    adata = AnnData(None, uns=dict(test=np.array((3, 3))), shape=shape)
+    assert adata.X is None
+    assert adata.shape == shape
+    
+    # test transpose
+    # check adata.T 

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -588,18 +588,21 @@ def test_x_is_none():
     adata = AnnData(np.array([[1, 2, 3], [4, 5, 6]]), dict(o1=[1, 2], o2=[3, 4]))
     adata.X = None
     assert adata.X is None
-    
+
     # test setter and deleter
     adata.X = np.array([[4, 5, 6], [1, 2, 3]])
     assert adata.X is not None
     del adata.X
     assert adata.X is None
-    
+
     # test initialiser
     shape = (3, 5)
     adata = AnnData(None, uns=dict(test=np.array((3, 3))), shape=shape)
     assert adata.X is None
     assert adata.shape == shape
-    
+
     # test transpose
-    # check adata.T 
+    adataT = adata.transpose()
+    assert_equal(adataT.shape, (5, 3))
+    assert_equal(adataT.obsp.keys(), adata.varp.keys())
+    assert_equal(adataT.T, adata)

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -582,8 +582,8 @@ def test_copy():
         for key in map_sprs.keys():
             assert_eq_not_id(map_sprs[key], map_copy[key])
 
+
 def test_delete_X():
     adata = AnnData(np.array([[1, 2, 3], [4, 5, 6]]), dict(o1=[1, 2], o2=[3, 4]))
     adata.X = None
     assert adata.X is None
-    

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -581,3 +581,9 @@ def test_copy():
         assert_eq_not_id(map_sprs.keys(), map_copy.keys())
         for key in map_sprs.keys():
             assert_eq_not_id(map_sprs[key], map_copy[key])
+
+def test_delete_X():
+    adata = AnnData(np.array([[1, 2, 3], [4, 5, 6]]), dict(o1=[1, 2], o2=[3, 4]))
+    adata.X = None
+    assert adata.X is None
+    

--- a/anndata/tests/test_transpose.py
+++ b/anndata/tests/test_transpose.py
@@ -34,9 +34,7 @@ def _add_raw(adata, *, var_subset=slice(None)):
         pytest.param(gen_adata((50, 20)), id="csr_X"),
         pytest.param(gen_adata((50, 20), sparse.csc_matrix), id="csc_X"),
         pytest.param(_add_raw(gen_adata((50, 20))), id="with_raw"),
-        pytest.param(
-            gen_adata((20, 10), X_type=None), id="None_X", marks=pytest.mark.xfail
-        ),
+        pytest.param(gen_adata((20, 10), X_type=None), id="None_X"),
     ]
 )
 def adata(request):

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -475,3 +475,14 @@ def test_view_retains_ndarray_subclass():
 
     assert isinstance(view.obsm["foo"], NDArraySubclass)
     assert view.obsm["foo"].shape == (5, 5)
+
+
+@pytest.mark.parametrize(
+    "attr", ["X", "obs", "var", "obsm", "varm", "obsp", "varp", "layers", "uns"]
+)
+def test_view_after_deletion(attr):
+    full = gen_adata((30, 30))
+    view = full[:, :20]
+    assert view.is_view
+    delattr(view, attr)
+    assert not view.is_view

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -367,17 +367,20 @@ def test_view_delitem(attr):
 
 
 @pytest.mark.parametrize(
-    "attr", ["obs", "var", "obsm", "varm", "obsp", "varp", "layers"]
+    "attr", ["X", "obs", "var", "obsm", "varm", "obsp", "varp", "layers", "uns"]
 )
-def test_view_delattr(attr):
+def test_view_delattr(attr, subset_func):
     base = gen_adata((10, 10))
-    # Indexing into obs and var just to get indexes
-    subset = base[5:7, :5]
-    empty = ad.AnnData(subset.X, obs=subset.obs[[]], var=subset.var[[]])
+    orig_hash = joblib.hash(base)
+    subset = base[subset_func(base.obs_names), subset_func(base.var_names)]
+    empty = ad.AnnData(obs=subset.obs[[]], var=subset.var[[]])
+
     delattr(subset, attr)
+
     assert not subset.is_view
     # Should now have same value as default
     assert_equal(getattr(subset, attr), getattr(empty, attr))
+    assert orig_hash == joblib.hash(base)  # Original should not be modified
 
 
 @pytest.mark.parametrize(
@@ -475,14 +478,3 @@ def test_view_retains_ndarray_subclass():
 
     assert isinstance(view.obsm["foo"], NDArraySubclass)
     assert view.obsm["foo"].shape == (5, 5)
-
-
-@pytest.mark.parametrize(
-    "attr", ["X", "obs", "var", "obsm", "varm", "obsp", "varp", "layers", "uns"]
-)
-def test_view_after_deletion(attr):
-    full = gen_adata((30, 30))
-    view = full[:, :20]
-    assert view.is_view
-    delattr(view, attr)
-    assert not view.is_view


### PR DESCRIPTION
Feature proposal for #464.

Need to test:
- [x] Getter (`test_base.py > test_x_is_none()`)
- [x] Setter (`test_base.py > test_x_is_none()`)
- [x] Deleter (`test_base.py > test_x_is_none()`)
- [x] Initializer (`test_base.py > test_x_is_none()`)
- [ ] Views
    * [ ] Check that .X = None doesn't change other view behavior
    * [ ] a[idx].X doesn't do anything weird
    * [ ] copying views still works
- [ ] _subset_inplace
- [ ] Copying
- [ ] Backed mode
- [ ] Concatenation
- [x] Transpose
- [ ] Methods which default to values from X, e.g. obs_vector, to_df.
- [ ] IO (seems to work, needs testing)
    * [ ] Maybe specialized writers like to_csvs will need some attention here?
- [ ] Raw (pretty similar set of things to be checked)
    * [ ] Initializer
    * [ ] Backed
    * [ ] Copies
    * [ ] Concatenation
    * [ ] IO
