### PR TITLE
Minor refactor of transpose tests

### DIFF
--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -104,6 +104,10 @@ def gen_adata(
     obs.rename(columns=dict(cat="obs_cat"), inplace=True)
     var.rename(columns=dict(cat="var_cat"), inplace=True)
 
+    if X_type is None:
+        X = None
+    else:
+        X = X_type(np.random.binomial(100, 0.005, (M, N)).astype(X_dtype))
     obsm = dict(
         array=np.random.random((M, 50)),
         sparse=sparse.random(M, 100, format="csr"),
@@ -131,7 +135,7 @@ def gen_adata(
         # U_recarray=gen_vstr_recarray(N, 5, "U4")
     )
     adata = AnnData(
-        X=X_type(np.random.binomial(100, 0.005, (M, N)).astype(X_dtype)),
+        X=X,
         obs=obs,
         var=var,
         obsm=obsm,

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -379,16 +379,6 @@ def test_get_subset_annotation():
     assert adata[0, 0].var["F"].tolist() == ["a"]
 
 
-def test_transpose():
-    adata = gen_adata((5, 3))
-    adata.varp = {f"varp_{k}": v for k, v in adata.varp.items()}
-    adata1 = adata.T
-    adata1.uns["test123"] = 1
-    assert "test123" in adata.uns
-    assert_equal(adata1.X.shape, (3, 5))
-    assert_equal(adata1.obsp.keys(), adata.varp.keys())
-
-
 def test_append_col():
     adata = AnnData(np.array([[1, 2, 3], [4, 5, 6]]))
 

--- a/anndata/tests/test_transpose.py
+++ b/anndata/tests/test_transpose.py
@@ -1,0 +1,74 @@
+from scipy import sparse
+
+import pytest
+
+from anndata.tests.helpers import gen_adata, assert_equal
+
+
+def test_transpose_orig():
+    """
+    Original test for transpose, should be covered by more thorough tests below, but
+    keeping around just in case.
+    """
+    adata = gen_adata((5, 3))
+    adata.varp = {f"varp_{k}": v for k, v in adata.varp.items()}
+    adata1 = adata.T
+    adata1.uns["test123"] = 1
+    assert "test123" in adata.uns
+    assert_equal(adata1.X.shape, (3, 5))
+    assert_equal(adata1.obsp.keys(), adata.varp.keys())
+
+
+def _add_raw(adata, *, var_subset=slice(None)):
+    new = adata[:, var_subset].copy()
+    new.raw = adata
+    return new
+
+
+# Cases to add:
+# * Views
+# * X is None
+# * Backed
+@pytest.fixture(
+    params=[
+        pytest.param(gen_adata((50, 20)), id="csr_X"),
+        pytest.param(gen_adata((50, 20), sparse.csc_matrix), id="csc_X"),
+        pytest.param(_add_raw(gen_adata((50, 20))), id="with_raw"),
+    ]
+)
+def adata(request):
+    return request.param
+
+
+def test_transpose_removes_raw(adata):
+    """
+    Since Raw must have the same `obs_names` as AnnData, but does not have the same
+    `var_names`, transpose doesn't really make sense for Raw. So it should just get
+    deleted.
+    """
+    assert adata.T.raw is None
+
+
+def test_transposed_contents(adata):
+    t = adata.T
+
+    if adata.X is not None:
+        assert_equal(adata.X.T, t.X)
+    else:
+        assert adata.X is t.X is None
+
+    assert_equal(
+        {k: v.T for k, v in adata.layers.items()}, {k: v for k, v in t.layers.items()}
+    )
+    assert_equal(adata.obs, t.var)
+    assert_equal(adata.var, t.obs)
+    assert_equal(dict(adata.obsm), dict(t.varm))
+    assert_equal(dict(adata.varm), dict(t.obsm))
+    assert_equal(dict(adata.obsp), dict(t.varp))
+    assert_equal(dict(adata.varp), dict(t.obsp))
+    assert_equal(adata.uns, t.uns)
+
+
+def test_transpose_roundtrip(adata):
+    del adata.raw
+    assert_equal(adata, adata.T.T)

--- a/anndata/tests/test_transpose.py
+++ b/anndata/tests/test_transpose.py
@@ -25,15 +25,18 @@ def _add_raw(adata, *, var_subset=slice(None)):
     return new
 
 
-# Cases to add:
+# TODO: Cases to add:
 # * Views
-# * X is None
+# * X is None should have the xfail marker removed
 # * Backed
 @pytest.fixture(
     params=[
         pytest.param(gen_adata((50, 20)), id="csr_X"),
         pytest.param(gen_adata((50, 20), sparse.csc_matrix), id="csc_X"),
         pytest.param(_add_raw(gen_adata((50, 20))), id="with_raw"),
+        pytest.param(
+            gen_adata((20, 10), X_type=None), id="None_X", marks=pytest.mark.xfail
+        ),
     ]
 )
 def adata(request):


### PR DESCRIPTION
Move transpose test to it's own file, added some property based tests. They will still need to be expanded, but this makes that easier.