### PR TITLE
Load backed data into memory more conveniently

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1419,7 +1419,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
     def copy(self, filename: Optional[PathLike] = None) -> "AnnData":
         """Full copy, optionally on disk."""
-        if not self.isbacked:
+        if not self.isbacked or filename is None:
             if self.is_view:
                 # TODO: How do I unambiguously check if this is a copy?
                 # Subsetting this way means we don’t have to have a view type
@@ -1435,6 +1435,14 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                     X = X.reshape(self.shape)
             else:
                 dtype = "float32"
+            raw = None
+            if self.raw is not None:
+                if self.isbacked:
+                    warnings.warn(
+                        "Dropping .raw attribute when copying from backed mode."
+                    )
+                else:
+                    raw = self.raw.copy()
             return AnnData(
                 X=X,
                 obs=self.obs.copy(),
@@ -1448,7 +1456,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 varm=self.varm.copy(),
                 obsp=self.obsp.copy(),
                 varp=self.varp.copy(),
-                raw=self.raw.copy() if self.raw is not None else None,
+                raw=raw,
                 layers=self.layers.copy(),
                 dtype=dtype,
             )

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1417,9 +1417,45 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         else:
             return self.raw.var_vector(k)
 
+    def _create_anndata(self, **kwargs):
+        """Creating AnnData with attributes optionally specified via kwargs."""
+        for key in ["obs", "var", "obsm", "varm", "obsp", "varp", "layers"]:
+            kwargs[key] = kwargs.pop(key, getattr(self, key).copy())
+        if "X" not in kwargs:
+            kwargs["X"] = (
+                self.X.to_memory()
+                if self.isbacked and hasattr(self.X, "to_memory")
+                else self.X.copy()
+            )
+        if "uns" not in kwargs:
+            kwargs["uns"] = (
+                self._uns.copy()
+                if isinstance(self.uns, DictView)
+                else deepcopy(self._uns)
+            )
+
+        kwargs["raw"] = kwargs.pop("raw", None)
+        if self.raw is not None:
+            if self.isbacked:
+                warnings.warn("Dropping .raw attribute when loading into memory mode.")
+            else:
+                kwargs["raw"] = self.raw.copy()
+        kwargs["dtype"] = kwargs["X"].dtype
+        return AnnData(**kwargs)
+
+    def to_memory(self) -> "AnnData":
+        """Loading AnnData object into memory."""
+        if not self.isbacked:
+            warnings.warn("Object is already in memory.")
+            adata = self
+        else:
+            adata = self._create_anndata()
+            self.file.close()
+        return adata
+
     def copy(self, filename: Optional[PathLike] = None) -> "AnnData":
         """Full copy, optionally on disk."""
-        if not self.isbacked or filename is None:
+        if not self.isbacked:
             if self.is_view:
                 # TODO: How do I unambiguously check if this is a copy?
                 # Subsetting this way means we don’t have to have a view type
@@ -1428,45 +1464,15 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 X = _subset(self._adata_ref.X, (self._oidx, self._vidx)).copy()
             else:
                 X = self.X.copy()
-            # TODO: Figure out what case this is:
-            if X is not None:
-                dtype = X.dtype
-                if X.shape != self.shape:
-                    X = X.reshape(self.shape)
-            else:
-                dtype = "float32"
-            raw = None
-            if self.raw is not None:
-                if self.isbacked:
-                    warnings.warn(
-                        "Dropping .raw attribute when copying from backed mode."
-                    )
-                else:
-                    raw = self.raw.copy()
-            return AnnData(
-                X=X,
-                obs=self.obs.copy(),
-                var=self.var.copy(),
-                # deepcopy on DictView does not work and is unnecessary
-                # as uns was copied already before
-                uns=self._uns.copy()
-                if isinstance(self.uns, DictView)
-                else deepcopy(self._uns),
-                obsm=self.obsm.copy(),
-                varm=self.varm.copy(),
-                obsp=self.obsp.copy(),
-                varp=self.varp.copy(),
-                raw=raw,
-                layers=self.layers.copy(),
-                dtype=dtype,
-            )
+            return self._create_anndata(X=X)
         else:
             from .._io import read_h5ad
 
             if filename is None:
                 raise ValueError(
                     "To copy an AnnData object in backed mode, "
-                    "pass a filename: `.copy(filename='myfilename.h5ad')`."
+                    "pass a filename: `.copy(filename='myfilename.h5ad')`. "
+                    "To load the object into memory, use `.to_memory()`."
                 )
             mode = self.file._filemode
             self.write(filename)

--- a/anndata/_core/raw.py
+++ b/anndata/_core/raw.py
@@ -129,16 +129,16 @@ class Raw:
     def copy(self):
         return Raw(
             self._adata,
-            X=self._X.copy(),
-            var=self._var.copy(),
+            X=self.X.copy(),
+            var=self.var.copy(),
             varm=None if self._varm is None else self._varm.copy(),
         )
 
     def to_adata(self):
         """Create full AnnData object."""
         return anndata.AnnData(
-            X=self._X.copy(),
-            var=self._var.copy(),
+            X=self.X.copy(),
+            var=self.var.copy(),
             varm=None if self._varm is None else self._varm.copy(),
             obs=self._adata.obs.copy(),
             obsm=self._adata.obsm.copy(),

--- a/anndata/tests/test_hdf5_backing.py
+++ b/anndata/tests/test_hdf5_backing.py
@@ -172,12 +172,13 @@ def test_backed_raw_subset(tmp_path, subset_func, subset_func2):
     backed_v.write_h5ad(final_pth)
 
     final_adata = ad.read_h5ad(final_pth)
-    # TODO: Figure out why this doesn’t work if I don’t copy
+    # todo: Figure out why this doesn’t work if I don’t copy
     assert_equal(final_adata, mem_v.copy())
 
-    final_adata_no_raw = final_adata.copy()
-    del final_adata_no_raw.raw  # .raw is dropped when loading backed into memory.
-    assert_equal(final_adata_no_raw, backed_v.copy())  # assert loading into memory
+    # todo: breaks when removing this line, b/c backed_v.X is not accessible
+    backed_v = ad.read_h5ad(backed_pth, backed="r")[obs_idx, var_idx]
+    del final_adata.raw  # .raw is dropped when loading backed into memory.
+    assert_equal(final_adata, backed_v.to_memory())  # assert loading into memory
 
 
 def test_double_index(adata, backing_h5ad):

--- a/anndata/tests/test_hdf5_backing.py
+++ b/anndata/tests/test_hdf5_backing.py
@@ -174,7 +174,10 @@ def test_backed_raw_subset(tmp_path, subset_func, subset_func2):
     final_adata = ad.read_h5ad(final_pth)
     # TODO: Figure out why this doesn’t work if I don’t copy
     assert_equal(final_adata, mem_v.copy())
-    assert_equal(final_adata, backed_v.copy())  # assert after loading into memory
+
+    final_adata_no_raw = final_adata.copy()
+    del final_adata_no_raw.raw  # .raw is dropped when loading backed into memory.
+    assert_equal(final_adata_no_raw, backed_v.copy())  # assert loading into memory
 
 
 def test_double_index(adata, backing_h5ad):

--- a/anndata/tests/test_hdf5_backing.py
+++ b/anndata/tests/test_hdf5_backing.py
@@ -168,12 +168,13 @@ def test_backed_raw_subset(tmp_path, subset_func, subset_func2):
     backed_v = backed_adata[obs_idx, var_idx]
     assert backed_v.is_view
     mem_v = mem_adata[obs_idx, var_idx]
-    assert_equal(backed_v, mem_v)
+    assert_equal(backed_v, mem_v)  # meaningful as objects are not equivalent?
     backed_v.write_h5ad(final_pth)
 
     final_adata = ad.read_h5ad(final_pth)
     # TODO: Figure out why this doesn’t work if I don’t copy
     assert_equal(final_adata, mem_v.copy())
+    assert_equal(final_adata, backed_v.copy())  # assert after loading into memory
 
 
 def test_double_index(adata, backing_h5ad):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ h5py
 natsort
 importlib_metadata>=0.7; python_version < '3.8'
 packaging>=20
+xlrd<2.0  # xlsx format not support anymore from v2.0, see pandas/issues/38524


### PR DESCRIPTION
Enables loading a backed anndata into memory via `AnnData.copy(filename=None)`, which previously required `filename` to be not `None` in backed mode.

Minimal example:
```
mem_adata = sc.datasets.blobs()
mem_adata.write(tmp_path)

backed_adata = ad.read(tmp_path, backed='r')
backed_to_mem = backed_adata[:, :5].copy()  # assert equal mem_adata[:, :5] 
```

Particularly useful to efficiently read large files only on a subset of genes. 