### PR TITLE
Write obsm keys to zattrs

### DIFF
--- a/anndata/_io/zarr.py
+++ b/anndata/_io/zarr.py
@@ -72,6 +72,8 @@ def write_attribute_zarr(f, key, value, dataset_kwargs=MappingProxyType({})):
 
 
 def write_mapping(f, key, value: Mapping, dataset_kwargs=MappingProxyType({})):
+    group = f.create_group(key)
+    group.attrs["column-order"] = list(value.keys())
     for sub_k, sub_v in value.items():
         if not isinstance(key, str):
             warn(

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -13,6 +13,7 @@ Release Notes
 - :attr:`~anndata.AnnData.filename` and :attr:`~anndata.AnnData.isbacked` will be unified under a new name.
 - The types of :attr:`~anndata.AnnData.raw`, :attr:`~anndata.AnnData.layers`, :attr:`~anndata.AnnData.obsm`,
   :attr:`~anndata.AnnData.varm`, :attr:`~anndata.AnnData.obsp` and :attr:`~anndata.AnnData.varp` will be exported.
+- :attr:`~anndata.AnnData.write_zarr` will write :attr:`~anndata.AnnData.obsm` keys to the `.zattrs` file.
 
 Version 0.7
 -----------


### PR DESCRIPTION
Hi, we are interested in using the zarr-based output of `.write_zarr`. Currently the `obsm` keys are not written to any metadata file. It would help if these keys were written to `obsm/.zattrs`