### PR TITLE
pin xlrd<2 for reading xlsx test file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
             "zarr",
             "matplotlib",
             "sklearn",
-            "xlrd",
+            "xlrd<2",
             "joblib",
             "boltons",
             "scanpy",


### PR DESCRIPTION
`xlrd` 2.x is out and [no longer reads `.xlsx` files](https://stackoverflow.com/a/65266270) which can cause `test_readwrite.py::test_read_excel` to fail; [example](https://github.com/celsiustx/anndata/runs/1577071982?check_suite_focus=true#step:8:2172):

```
=================================== FAILURES ===================================
_______________________________ test_read_excel ________________________________

    def test_read_excel():
>       adata = ad.read_excel(HERE / "data/excel.xlsx", "Sheet1", dtype=int)

anndata/tests/test_readwrite.py:365: 
…
        file_format = inspect_format(filename, file_contents)
        # We have to let unknown file formats pass through here, as some ancient
        # files that xlrd can parse don't start with the expected signature.
        if file_format and file_format != 'xls':
>           raise XLRDError(FILE_FORMAT_DESCRIPTIONS[file_format]+'; not supported')
E           xlrd.biffh.XLRDError: Excel xlsx file; not supported

/usr/local/lib/python3.7/site-packages/xlrd/__init__.py:170: XLRDError
```

I guess [`openpyxl` is the preferred way of reading `.xlsx`s now](http://www.python-excel.org/), so we could update to that (`pd.read_excel(…, engine='openpyxl')` everywhere?), but in the meantime it seems simple to just pin `xlrd<2`.