### PR TITLE
Fix sklearn testing usage

### DIFF
--- a/anndata/tests/test_inplace_subset.py
+++ b/anndata/tests/test_inplace_subset.py
@@ -1,9 +1,8 @@
 import numpy as np
 import pytest
-from sklearn.utils.testing import assert_array_equal
 from scipy import sparse
 
-from anndata.tests.helpers import gen_adata, subset_func
+from anndata.tests.helpers import assert_equal, gen_adata, subset_func
 from anndata.utils import asarray
 
 
@@ -24,16 +23,18 @@ def test_inplace_subset_var(matrix_type, subset_func):
     from_view = orig[:, subset_idx].copy()
     modified._inplace_subset_var(subset_idx)
 
-    assert_array_equal(asarray(from_view.X), asarray(modified.X))
-    assert_array_equal(from_view.obs, modified.obs)
-    assert_array_equal(from_view.var, modified.var)
+    assert_equal(asarray(from_view.X), asarray(modified.X), exact=True)
+    assert_equal(from_view.obs, modified.obs, exact=True)
+    assert_equal(from_view.var, modified.var, exact=True)
     for k in from_view.obsm:
-        assert_array_equal(asarray(from_view.obsm[k]), asarray(modified.obsm[k]))
-        assert_array_equal(asarray(orig.obsm[k]), asarray(modified.obsm[k]))
+        assert_equal(asarray(from_view.obsm[k]), asarray(modified.obsm[k]), exact=True)
+        assert_equal(asarray(orig.obsm[k]), asarray(modified.obsm[k]), exact=True)
     for k in from_view.varm:
-        assert_array_equal(asarray(from_view.varm[k]), asarray(modified.varm[k]))
+        assert_equal(asarray(from_view.varm[k]), asarray(modified.varm[k]), exact=True)
     for k in from_view.layers:
-        assert_array_equal(asarray(from_view.layers[k]), asarray(modified.layers[k]))
+        assert_equal(
+            asarray(from_view.layers[k]), asarray(modified.layers[k]), exact=True
+        )
 
 
 def test_inplace_subset_obs(matrix_type, subset_func):
@@ -44,13 +45,15 @@ def test_inplace_subset_obs(matrix_type, subset_func):
     from_view = orig[subset_idx, :].copy()
     modified._inplace_subset_obs(subset_idx)
 
-    assert_array_equal(asarray(from_view.X), asarray(modified.X))
-    assert_array_equal(from_view.obs, modified.obs)
-    assert_array_equal(from_view.var, modified.var)
+    assert_equal(asarray(from_view.X), asarray(modified.X), exact=True)
+    assert_equal(from_view.obs, modified.obs, exact=True)
+    assert_equal(from_view.var, modified.var, exact=True)
     for k in from_view.obsm:
-        assert_array_equal(asarray(from_view.obsm[k]), asarray(modified.obsm[k]))
+        assert_equal(asarray(from_view.obsm[k]), asarray(modified.obsm[k]), exact=True)
     for k in from_view.varm:
-        assert_array_equal(asarray(from_view.varm[k]), asarray(modified.varm[k]))
-        assert_array_equal(asarray(orig.varm[k]), asarray(modified.varm[k]))
+        assert_equal(asarray(from_view.varm[k]), asarray(modified.varm[k]), exact=True)
+        assert_equal(asarray(orig.varm[k]), asarray(modified.varm[k]), exact=True)
     for k in from_view.layers:
-        assert_array_equal(asarray(from_view.layers[k]), asarray(modified.layers[k]))
+        assert_equal(
+            asarray(from_view.layers[k]), asarray(modified.layers[k]), exact=True
+        )


### PR DESCRIPTION
`sklearn.utils.testing.assert_arrays_equal` was removed for 0.24.0.