### PR TITLE
Redo azure coverage and test reporting

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -28,12 +28,12 @@ jobs:
     displayName: 'Install dependencies'
 
   - script: |
-      pytest --junitxml=junit/test-results.xml
+      pytest --color=yes --junitxml=junit/test-results.xml
     displayName: 'PyTest'
     condition: eq(variables['RUN_COVERAGE'], 'no')
 
   - script: |
-      pytest --junitxml=junit/test-results.xml --cov --cov-report=xml
+      pytest --color=yes --junitxml=junit/test-results.xml --cov --cov-report=xml
     displayName: 'PyTest (coverage)'
     condition: eq(variables['RUN_COVERAGE'], 'yes')
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -28,12 +28,12 @@ jobs:
     displayName: 'Install dependencies'
 
   - script: |
-      pytest
-    displayName: 'PyTest (coverage)'
+      pytest --junitxml=junit/test-results.xml
+    displayName: 'PyTest'
     condition: eq(variables['RUN_COVERAGE'], 'no')
 
   - script: |
-      pytest --cov=. --cov-report=xml
+      pytest --junitxml=junit/test-results.xml --cov --cov-report=xml
     displayName: 'PyTest (coverage)'
     condition: eq(variables['RUN_COVERAGE'], 'yes')
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,6 +1,9 @@
 trigger:
 - master
 
+variables:
+  RUN_COVERAGE: no
+
 jobs:
 - job: PyTest
   pool:
@@ -9,6 +12,7 @@ jobs:
     matrix:
       Python37:
         python.version: '3.7'
+        RUN_COVERAGE: yes
       Python36:
         python.version: '3.6'
   steps:
@@ -19,13 +23,32 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip
-      pip install pytest-azurepipelines wheel
+      pip install pytest-cov wheel
       pip install .[dev,test]
     displayName: 'Install dependencies'
 
   - script: |
+      pytest
+    displayName: 'PyTest (coverage)'
+    condition: eq(variables['RUN_COVERAGE'], 'no')
+
+  - script: |
       pytest --cov=. --cov-report=xml
-    displayName: 'PyTest'
+    displayName: 'PyTest (coverage)'
+    condition: eq(variables['RUN_COVERAGE'], 'yes')
+
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+      reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
+    condition: eq(variables['RUN_COVERAGE'], 'yes')
+
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: 'junit/test-*.xml'
+      testRunTitle: 'Publish test results for Python $(python.version)'
 
 - job: static_analysis
   pool:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,0 @@
-[run]
-source=anndata
-omit=
-	setup.py
-	versioneer.py
-	anndata/_version.py
-	anndata/tests/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,15 @@ author = 'Philipp Angerer, Alex Wolf, Isaac Virshup, Sergei Rybakov'
 # We don’t need all emails, the main authors are sufficient.
 author-email = 'phil.angerer@gmail.com, f.alex.wolf@gmx.de'
 
+[tool.coverage.run]
+source = ['anndata']
+omit = [
+	'setup.py',
+	'versioneer.py',
+	'anndata/_version.py',
+	'**/test_*.py',
+]
+
 [tool.pytest.ini_options]
 addopts = '--doctest-modules'
 python_files = 'test_*.py'


### PR DESCRIPTION
Sibling to https://github.com/theislab/scanpy/pull/1564

* Stop using pytest-azurepipelines, since it's error reporting is annoying
* Only do coverage for one run (since it's slow)
* Manually upload coverage and tests

At some point it would be good to use codecov or a similar tool for coverage. That's more disruptive so will require some team input.