### PR TITLE
remove_unused_categories(inplace=True) is deprecated

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1113,7 +1113,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             if not is_categorical_dtype(df_full[k]):
                 continue
             all_categories = df_full[k].cat.categories
-            df_sub[k].cat.remove_unused_categories(inplace=True)
+            df_sub[k] = df_sub[k].cat.remove_unused_categories()
             # also correct the colors...
             color_key = f"{k}_colors"
             if color_key not in uns:


### PR DESCRIPTION
in pandas 1.2.0: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.cat.remove_unused_categories.html