### PR TITLE
Fix a.X = X when 1 in X.shape and isinstance(X, sparse.spmatrix)

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -669,9 +669,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             oidx, vidx = self._oidx, self._vidx
         if (
             np.isscalar(value)
+            or (hasattr(value, "shape") and (self.shape == value.shape))
             or (self.n_vars == 1 and self.n_obs == len(value))
             or (self.n_obs == 1 and self.n_vars == len(value))
-            or self.shape == value.shape
         ):
             if not np.isscalar(value) and self.shape != value.shape:
                 # For assigning vector of values to 2d array or matrix

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -571,28 +571,3 @@ def test_copy():
         assert_eq_not_id(map_sprs.keys(), map_copy.keys())
         for key in map_sprs.keys():
             assert_eq_not_id(map_sprs[key], map_copy[key])
-
-
-def test_x_is_none():
-    # test setter and getter
-    adata = AnnData(np.array([[1, 2, 3], [4, 5, 6]]), dict(o1=[1, 2], o2=[3, 4]))
-    adata.X = None
-    assert adata.X is None
-
-    # test setter and deleter
-    adata.X = np.array([[4, 5, 6], [1, 2, 3]])
-    assert adata.X is not None
-    del adata.X
-    assert adata.X is None
-
-    # test initialiser
-    shape = (3, 5)
-    adata = AnnData(None, uns=dict(test=np.array((3, 3))), shape=shape)
-    assert adata.X is None
-    assert adata.shape == shape
-
-    # test transpose
-    adataT = adata.transpose()
-    assert_equal(adataT.shape, (5, 3))
-    assert_equal(adataT.obsp.keys(), adata.varp.keys())
-    assert_equal(adataT.T, adata)

--- a/anndata/tests/test_x.py
+++ b/anndata/tests/test_x.py
@@ -1,0 +1,27 @@
+"""Tests for the attribute .X"""
+import numpy as np
+from scipy import sparse
+
+from anndata.utils import asarray
+
+import pytest
+
+from anndata.tests.helpers import gen_adata
+
+UNLABELLED_ARRAY_TYPES = [
+    pytest.param(sparse.csr_matrix, id="csr"),
+    pytest.param(sparse.csc_matrix, id="csc"),
+    pytest.param(asarray, id="ndarray"),
+]
+SINGULAR_SHAPES = [
+    pytest.param(shape, id=str(shape)) for shape in [(1, 10), (10, 1), (1, 1)]
+]
+
+
+@pytest.mark.parametrize("shape", SINGULAR_SHAPES)
+@pytest.mark.parametrize("orig_array_type", UNLABELLED_ARRAY_TYPES)
+@pytest.mark.parametrize("new_array_type", UNLABELLED_ARRAY_TYPES)
+def test_setter_singular_dim(shape, orig_array_type, new_array_type):
+    adata = gen_adata(shape, X_type=orig_array_type)
+    adata.X = new_array_type(np.ones(shape))
+    np.testing.assert_equal(asarray(adata.X), 1)

--- a/anndata/tests/test_x.py
+++ b/anndata/tests/test_x.py
@@ -2,11 +2,12 @@
 import numpy as np
 from scipy import sparse
 
+from anndata import AnnData
 from anndata.utils import asarray
 
 import pytest
 
-from anndata.tests.helpers import gen_adata
+from anndata.tests.helpers import gen_adata, assert_equal
 
 UNLABELLED_ARRAY_TYPES = [
     pytest.param(sparse.csr_matrix, id="csr"),
@@ -22,6 +23,53 @@ SINGULAR_SHAPES = [
 @pytest.mark.parametrize("orig_array_type", UNLABELLED_ARRAY_TYPES)
 @pytest.mark.parametrize("new_array_type", UNLABELLED_ARRAY_TYPES)
 def test_setter_singular_dim(shape, orig_array_type, new_array_type):
+    # https://github.com/theislab/anndata/issues/500
     adata = gen_adata(shape, X_type=orig_array_type)
     adata.X = new_array_type(np.ones(shape))
     np.testing.assert_equal(asarray(adata.X), 1)
+
+
+###############################
+# Tests for `adata.X is None` #
+###############################
+
+
+def test_set_x_is_none():
+    # test setter and getter
+    adata = AnnData(np.array([[1, 2, 3], [4, 5, 6]]), dict(o1=[1, 2], o2=[3, 4]))
+    adata.X = None
+    assert adata.X is None
+
+
+def test_del_set_equiv_X():
+    """Tests that `del adata.X` is equivalent to `adata.X = None`"""
+    # test setter and deleter
+    orig = gen_adata((10, 10))
+    copy = orig.copy()
+
+    del orig.X
+    copy.X = None
+
+    assert orig.X is None
+    assert_equal(orig, copy)
+
+    # Check that deleting again is still fine
+    del orig.X
+    assert orig.X is None
+
+
+def test_init_X_as_none():
+    # test initialiser
+    shape = (3, 5)
+    adata = AnnData(None, uns=dict(test=np.array((3, 3))), shape=shape)
+    assert adata.X is None
+    assert adata.shape == shape
+
+
+@pytest.mark.parametrize("shape", SINGULAR_SHAPES + [pytest.param((5, 3), id="(5, 3)")])
+def test_transpose_with_X_as_none(shape):
+    adata = gen_adata(shape, X_type=lambda x: None)
+    adataT = adata.transpose()
+    assert_equal(adataT.shape, shape[::-1])
+    assert_equal(adataT.obsp.keys(), adata.varp.keys())
+    assert_equal(adataT.T, adata)


### PR DESCRIPTION
Fixes #500

Also added a new file for tests to `.X` since adding more there felt wrong. Should probably start a module for testing attributes.