### PR TITLE
Fix version on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 dist: xenial
 language: python
+git:
+  depth: false  # Version detection needs all info
 cache: pip
 branches:
   only:


### PR DESCRIPTION
Master is currently failing on Travis because Travis clones the repo using `--depth=50`, resulting in the version being `0.1.dev50+hash`, causing scanpy to cry bloody murder.

This hopefully fixes it, maybe a `git fetch --tags` is also in order. (edit: nope, fixed!)