### PR TITLE
Fix conversion of string arrays to categorical when arrays contain null values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 dist: xenial
 language: python
+git:
+  depth: false  # Version detection needs all info
 cache: pip
 branches:
   only:

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1209,16 +1209,14 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 key for key in df.columns if infer_dtype(df[key]) == "string"
             ]
             for key in string_cols:
-                # make sure we only have strings
-                # (could be that there are np.nans (float), -666, "-666", for instance)
-                # make a categorical
-                col = df[key]
-                c = pd.Categorical(
-                    col,
-                    categories=natsorted(pd.unique(col[col.notnull()])),
-                )
+                c = pd.Categorical(df[key])
+                # TODO: We should only check if non-null values are unique, but
+                # this would break cases where string columns with nulls could
+                # be written as categorical, but not as string.
+                # Possible solution: https://github.com/theislab/anndata/issues/504
                 if len(c.categories) >= len(c):
                     continue
+                c.reorder_categories(natsorted(c.categories), inplace=True)
                 if dont_modify:
                     raise RuntimeError(
                         "Please call `.strings_to_categoricals()` on full "

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1213,9 +1213,9 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             for key in string_cols:
                 # make sure we only have strings
                 # (could be that there are np.nans (float), -666, "-666", for instance)
-                c = df[key].astype("U")
                 # make a categorical
-                c = pd.Categorical(c, categories=natsorted(np.unique(c)))
+                col = df[key]
+                c = pd.Categorical(col, categories=natsorted(pd.unique(col[col.notnull()])))
                 if len(c.categories) >= len(c):
                     continue
                 if dont_modify:

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -18,7 +18,7 @@ from natsort import natsorted
 import numpy as np
 from numpy import ma
 import pandas as pd
-from pandas.api.types import is_string_dtype, is_categorical_dtype
+from pandas.api.types import infer_dtype, is_string_dtype, is_categorical_dtype
 from scipy import sparse
 from scipy.sparse import issparse, csr_matrix
 
@@ -1208,7 +1208,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             string_cols = [
                 key
                 for key in df.columns
-                if is_string_dtype(df[key]) and not is_categorical_dtype(df[key])
+                if infer_dtype(df[key]) == "string"
             ]
             for key in string_cols:
                 # make sure we only have strings

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1206,16 +1206,17 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             dfs = [df]
         for df in dfs:
             string_cols = [
-                key
-                for key in df.columns
-                if infer_dtype(df[key]) == "string"
+                key for key in df.columns if infer_dtype(df[key]) == "string"
             ]
             for key in string_cols:
                 # make sure we only have strings
                 # (could be that there are np.nans (float), -666, "-666", for instance)
                 # make a categorical
                 col = df[key]
-                c = pd.Categorical(col, categories=natsorted(pd.unique(col[col.notnull()])))
+                c = pd.Categorical(
+                    col,
+                    categories=natsorted(pd.unique(col[col.notnull()])),
+                )
                 if len(c.categories) >= len(c):
                     continue
                 if dont_modify:

--- a/anndata/tests/test_annot.py
+++ b/anndata/tests/test_annot.py
@@ -9,30 +9,37 @@ import pytest
 
 @pytest.mark.parametrize("dtype", [object, "string"])
 def test_str_to_categorical(dtype):
-    M, N = (5, 5)
     obs = pd.DataFrame(
-        {"str": ["a", "a", None, "b", "b"]}, index=[f"cell-{i}" for i in range(M)]
+        {"str": ["a", "a", None, "b", "b"]}, index=[f"cell-{i}" for i in range(5)]
     )
     obs["str"] = obs["str"].astype(dtype)
-    a = ad.AnnData(np.ones((M, N)), obs=obs.copy())
+    a = ad.AnnData(obs=obs.copy())
+
     a.strings_to_categoricals()
-    cat = obs["str"].astype("category")
-    pd.testing.assert_series_equal(a.obs["str"], cat)
+    expected = obs["str"].astype("category")
+    pd.testing.assert_series_equal(expected, a.obs["str"])
 
 
 def test_non_str_to_not_categorical():
     # Test case based on https://github.com/theislab/anndata/issues/141#issuecomment-802105259
-    adata = ad.AnnData(
-        obs=pd.DataFrame().assign(
-            str_with_nan=["foo", "bar", None, np.nan, "foo"],
-            boolean_with_nan_and_none=[True, False, np.nan, None, True],
-            boolean_with_nan=[True, False, np.nan, np.nan, True],
-            boolean_with_none=[True, False, None, None, True],
-        )
+    obs = pd.DataFrame(index=[f"cell-{i}" for i in range(5)]).assign(
+        str_with_nan=["foo", "bar", None, np.nan, "foo"],
+        boolean_with_nan_and_none=[True, False, np.nan, None, True],
+        boolean_with_nan=[True, False, np.nan, np.nan, True],
+        boolean_with_none=[True, False, None, None, True],
     )
-    orig_dtypes = {k: v.name for k, v in adata.obs.dtypes.items()}
+    adata = ad.AnnData(obs=obs.copy())
+
+    orig_dtypes = {k: v.name for k, v in obs.dtypes.items()}
     expected_dtypes = orig_dtypes.copy()
     expected_dtypes["str_with_nan"] = "category"
+
     adata.strings_to_categoricals()
     result_dtypes = {k: v.name for k, v in adata.obs.dtypes.items()}
+
     assert expected_dtypes == result_dtypes
+
+    expected_non_transformed = obs.drop(columns=["str_with_nan"])
+    result_non_trasnformed = adata.obs.drop(columns=["str_with_nan"])
+
+    pd.testing.assert_frame_equal(expected_non_transformed, result_non_trasnformed)

--- a/anndata/tests/test_annot.py
+++ b/anndata/tests/test_annot.py
@@ -1,0 +1,38 @@
+"""Test handling of values in `obs`/ `var`"""
+import numpy as np
+import pandas as pd
+
+import anndata as ad
+
+import pytest
+
+
+@pytest.mark.parametrize("dtype", [object, "string"])
+def test_str_to_categorical(dtype):
+    M, N = (5, 5)
+    obs = pd.DataFrame(
+        {"str": ["a", "a", None, "b", "b"]}, index=[f"cell-{i}" for i in range(M)]
+    )
+    obs["str"] = obs["str"].astype(dtype)
+    a = ad.AnnData(np.ones((M, N)), obs=obs.copy())
+    a.strings_to_categoricals()
+    cat = obs["str"].astype("category")
+    pd.testing.assert_series_equal(a.obs["str"], cat)
+
+
+def test_non_str_to_not_categorical():
+    # Test case based on https://github.com/theislab/anndata/issues/141#issuecomment-802105259
+    adata = ad.AnnData(
+        obs=pd.DataFrame().assign(
+            str_with_nan=["foo", "bar", None, np.nan, "foo"],
+            boolean_with_nan_and_none=[True, False, np.nan, None, True],
+            boolean_with_nan=[True, False, np.nan, np.nan, True],
+            boolean_with_none=[True, False, None, None, True],
+        )
+    )
+    orig_dtypes = {k: v.name for k, v in adata.obs.dtypes.items()}
+    expected_dtypes = orig_dtypes.copy()
+    expected_dtypes["str_with_nan"] = "category"
+    adata.strings_to_categoricals()
+    result_dtypes = {k: v.name for k, v in adata.obs.dtypes.items()}
+    assert expected_dtypes == result_dtypes

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -128,15 +128,16 @@ def test_readwrite_h5ad(typ, dataset_kwargs, backing_h5ad):
     assert not is_categorical_dtype(adata.obs["oanno2"])
     assert adata.obs.index.tolist() == ["name1", "name2", "name3"]
     assert adata.obs["oanno1"].cat.categories.tolist() == ["cat1", "cat2"]
+    assert adata.obs["oanno1c"].cat.categories.tolist() == ["cat1"]
     assert is_categorical_dtype(adata.raw.var["vanno2"])
-    assert np.all(adata.obs == adata_src.obs)
-    assert np.all(adata.var == adata_src.var)
+    pd.testing.assert_frame_equal(adata.obs, adata_src.obs)
+    pd.testing.assert_frame_equal(adata.var, adata_src.var)
     assert np.all(adata.var.index == adata_src.var.index)
     assert adata.var.index.dtype == adata_src.var.index.dtype
     assert type(adata.raw.X) is type(adata_src.raw.X)
     assert type(adata.raw.varm) is type(adata_src.raw.varm)
     assert np.allclose(asarray(adata.raw.X), asarray(adata_src.raw.X))
-    assert np.all(adata.raw.var == adata_src.raw.var)
+    pd.testing.assert_frame_equal(adata.raw.var, adata_src.raw.var)
     assert isinstance(adata.uns["uns4"]["a"], (int, np.integer))
     assert isinstance(adata_src.uns["uns4"]["a"], (int, np.integer))
     assert type(adata.uns["uns4"]["c"]) is type(adata_src.uns["uns4"]["c"])
@@ -157,9 +158,10 @@ def test_readwrite_zarr(typ, tmp_path):
     assert not is_categorical_dtype(adata.obs["oanno2"])
     assert adata.obs.index.tolist() == ["name1", "name2", "name3"]
     assert adata.obs["oanno1"].cat.categories.tolist() == ["cat1", "cat2"]
+    assert adata.obs["oanno1c"].cat.categories.tolist() == ["cat1"]
     assert is_categorical_dtype(adata.raw.var["vanno2"])
-    assert np.all(adata.obs == adata_src.obs)
-    assert np.all(adata.var == adata_src.var)
+    pd.testing.assert_frame_equal(adata.obs, adata_src.obs)
+    pd.testing.assert_frame_equal(adata.var, adata_src.var)
     assert np.all(adata.var.index == adata_src.var.index)
     assert adata.var.index.dtype == adata_src.var.index.dtype
     assert type(adata.raw.X) is type(adata_src.raw.X)

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -9,6 +9,7 @@ On master
 - Fixed bug where `np.str_` column names errored at write time :pr:`457` :smaller:`I Virshup`
 - Fixed "value.index does not match parent’s axis 0/1 names" error triggered when a data frame is stored in obsm/varm after obs_names/var_names is updated :pr:`461` :smaller:`G Eraslan`
 - Fixed `adata.write_csvs` when `adata` is a view :pr:`462` :smaller:`I Virshup`
+- Fixed null values being converted to strings when strings are converted to categorical :pr:`529` :smaller:`I Virshup`
 
 0.7.5 :small:`2020-11-12`
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #141

## TODO:

- [x] Add tests to make sure other dtypes are mistakenly converted
- [x] Benchmark conversion a bit
- [x] Release note