### PR TITLE
fix copying of backed files (closes #519)

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1488,6 +1488,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             return self._create_anndata(X=X)
         else:
             from .._io import read_h5ad
+            from .._io.write import _write_h5ad
 
             if filename is None:
                 raise ValueError(
@@ -1496,7 +1497,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                     "To load the object into memory, use `.to_memory()`."
                 )
             mode = self.file._filemode
-            self.write(filename)
+            _write_h5ad(filename, self)
             return read_h5ad(filename, backed=mode)
 
     def concatenate(
@@ -1886,7 +1887,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         )
 
         if self.isbacked:
-            self.file.close()
+            self.file.filename = filename
 
     write = write_h5ad  # a shortcut and backwards compat
 

--- a/anndata/_io/h5ad.py
+++ b/anndata/_io/h5ad.py
@@ -116,8 +116,6 @@ def write_h5ad(
         write_attribute(f, "varp", adata.varp, dataset_kwargs=dataset_kwargs)
         write_attribute(f, "layers", adata.layers, dataset_kwargs=dataset_kwargs)
         write_attribute(f, "uns", adata.uns, dataset_kwargs=dataset_kwargs)
-    if adata.isbacked:
-        adata.file.open(filepath, "r+")
 
 
 def _write_method(cls: Type[T]) -> Callable[[H5Group, str, T], None]:

--- a/anndata/tests/test_hdf5_backing.py
+++ b/anndata/tests/test_hdf5_backing.py
@@ -139,6 +139,19 @@ def test_backing(adata, tmp_path, backing_h5ad):
     adata_subset.write()
 
 
+def test_backing_copy(adata, tmp_path, backing_h5ad):
+    adata.filename = backing_h5ad
+    adata.write()
+
+    copypath = tmp_path / "test.copy.h5ad"
+    copy = adata.copy(copypath)
+
+    assert adata.filename == backing_h5ad
+    assert copy.filename == copypath
+    assert adata.isbacked
+    assert copy.isbacked
+
+
 # TODO: Also test updating the backing file inplace
 def test_backed_raw(tmp_path):
     backed_pth = tmp_path / "backed.h5ad"

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -9,6 +9,7 @@ On master
 - Fixed bug where `np.str_` column names errored at write time :pr:`457` :smaller:`I Virshup`
 - Fixed "value.index does not match parent’s axis 0/1 names" error triggered when a data frame is stored in obsm/varm after obs_names/var_names is updated :pr:`461` :smaller:`G Eraslan`
 - Fixed `adata.write_csvs` when `adata` is a view :pr:`462` :smaller:`I Virshup`
+- Fixed copying a backed `AnnData` from changing which file the original object points at :pr:`533` :smaller:`ilia-kats`
 
 0.7.5 :small:`2020-11-12`
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
don't overwrite the original file's filename with the new one