### PR TITLE
Fix handling of compression kwargs

### DIFF
--- a/anndata/_io/h5ad.py
+++ b/anndata/_io/h5ad.py
@@ -288,7 +288,7 @@ def write_series(group, key, series, dataset_kwargs=MappingProxyType({})):
         group[key].attrs["categories"] = group[category_key].ref
         group[category_key].attrs["ordered"] = categorical.ordered
     else:
-        group[key] = series.values
+        write_array(group, key, series.values, dataset_kwargs=dataset_kwargs)
 
 
 def write_mapping(f, key, value, dataset_kwargs=MappingProxyType({})):

--- a/anndata/_io/zarr.py
+++ b/anndata/_io/zarr.py
@@ -133,7 +133,7 @@ def write_series(group, key, series, dataset_kwargs=MappingProxyType({})):
         # Must coerce np.bool_ to bool for json writing
         group[category_key].attrs["ordered"] = bool(categorical.ordered)
     else:
-        group[key] = series.values
+        write_array(group, key, series.values, dataset_kwargs=dataset_kwargs)
 
 
 @report_write_key_on_error
@@ -183,25 +183,25 @@ def write_none(f, key, value, dataset_kwargs=MappingProxyType({})):
 
 # TODO: Figure out what to do with dataset_kwargs for these
 @report_write_key_on_error
-def write_csr(f, key, value, dataset_kwargs=MappingProxyType({})):
+def write_csr(f, key, value: sparse.csr_matrix, dataset_kwargs=MappingProxyType({})):
     group = f.create_group(key)
     group.attrs["encoding-type"] = "csr_matrix"
     group.attrs["encoding-version"] = EncodingVersions.csr_matrix.value
     group.attrs["shape"] = value.shape
-    group["data"] = value.data
-    group["indices"] = value.indices
-    group["indptr"] = value.indptr
+    write_array(group, "data", value.data, dataset_kwargs=dataset_kwargs)
+    write_array(group, "indices", value.indices, dataset_kwargs=dataset_kwargs)
+    write_array(group, "indptr", value.indptr, dataset_kwargs=dataset_kwargs)
 
 
 @report_write_key_on_error
-def write_csc(f, key, value, dataset_kwargs=MappingProxyType({})):
+def write_csc(f, key, value: sparse.csc_matrix, dataset_kwargs=MappingProxyType({})):
     group = f.create_group(key)
     group.attrs["encoding-type"] = "csc_matrix"
     group.attrs["encoding-version"] = EncodingVersions.csc_matrix.value
     group.attrs["shape"] = value.shape
-    group["data"] = value.data
-    group["indices"] = value.indices
-    group["indptr"] = value.indptr
+    write_array(group, "data", value.data, dataset_kwargs=dataset_kwargs)
+    write_array(group, "indices", value.indices, dataset_kwargs=dataset_kwargs)
+    write_array(group, "indptr", value.indptr, dataset_kwargs=dataset_kwargs)
 
 
 def write_raw(f, key, value, dataset_kwargs=MappingProxyType({})):

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -10,6 +10,7 @@ On master
 - Fixed "value.index does not match parent’s axis 0/1 names" error triggered when a data frame is stored in obsm/varm after obs_names/var_names is updated :pr:`461` :smaller:`G Eraslan`
 - Fixed `adata.write_csvs` when `adata` is a view :pr:`462` :smaller:`I Virshup`
 - Fixed null values being converted to strings when strings are converted to categorical :pr:`529` :smaller:`I Virshup`
+- Fixed handling of compression key word arguments :pr:`536` :smaller:`I Virshup`
 
 0.7.5 :small:`2020-11-12`
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
* Dataframe columns weren't being compressed in h5ad
* Added tests for compression kwargs being passed correctly for hdf5 and zarr backends
* Zarr wasn't passing compression options for sparse arrays.

Open question: is there a reason we don't allow passing kwargs to `write_zarr`? iirc, there was some issue with it being better to just manage the store directly, since arguments could be handled there?