### PR TITLE
Allow passing dimension names to and from loom

### DIFF
--- a/anndata/_io/read.py
+++ b/anndata/_io/read.py
@@ -1,16 +1,19 @@
 from pathlib import Path
 from os import PathLike, fspath
+from types import MappingProxyType
 from typing import Union, Optional, Mapping, Tuple
 from typing import Iterable, Iterator, Generator
 from collections import OrderedDict
 import gzip
 import bz2
+from warnings import warn
 
 import h5py
 import numpy as np
 import pandas as pd
 
 from .. import AnnData
+from ..compat import _deprecate_positional_args
 from .utils import is_float
 from .h5ad import read_h5ad
 
@@ -145,11 +148,11 @@ def read_hdf(filename: PathLike, key: str) -> AnnData:
 
 
 def _fmt_loom_axis_attrs(
-    input: Mapping, idx_name: str, mapped_names: Mapping[str, Iterable[str]]
+    input: Mapping, idx_name: str, dimm_mapping: Mapping[str, Iterable[str]]
 ) -> Tuple[pd.DataFrame, Mapping[str, np.ndarray]]:
     axis_df = pd.DataFrame()
     axis_mapping = {}
-    for key, names in mapped_names.items():
+    for key, names in dimm_mapping.items():
         axis_mapping[key] = np.array([input.pop(name) for name in names]).T
 
     for k, v in input.items():
@@ -164,8 +167,10 @@ def _fmt_loom_axis_attrs(
     return axis_df, axis_mapping
 
 
+@_deprecate_positional_args(version="0.9")
 def read_loom(
     filename: PathLike,
+    *,
     sparse: bool = True,
     cleanup: bool = False,
     X_name: str = "spliced",
@@ -174,6 +179,8 @@ def read_loom(
     var_names: str = "Gene",
     varm_names: Optional[Mapping[str, Iterable[str]]] = None,
     dtype: str = "float32",
+    obsm_mapping: Mapping[str, Iterable[str]] = MappingProxyType({}),
+    varm_mapping: Mapping[str, Iterable[str]] = MappingProxyType({}),
     **kwargs,
 ) -> AnnData:
     """\
@@ -184,7 +191,7 @@ def read_loom(
     Beware that you have to explicitly state when you want to read the file as
     sparse data.
 
-    Parameters
+        Parameters
     ----------
     filename
         The filename.
@@ -197,17 +204,56 @@ def read_loom(
         Loompy key with which the data matrix :attr:`~anndata.AnnData.X` is initialized.
     obs_names
         Loompy key where the observation/cell names are stored.
-    obsm_names
+    obsm_mapping
         Loompy keys which will be constructed into observation matrices
     var_names
         Loompy key where the variable/gene names are stored.
-    varm_names
+    varm_mapping
         Loompy keys which will be constructed into variable matrices
     **kwargs:
         Arguments to loompy.connect
+
+    Example
+    -------
+
+    .. code:: python
+
+        pbmc = anndata.read_loom(
+            "pbmc.loom",
+            sparse=True,
+            X_name="lognorm",
+            obs_names="cell_names",
+            var_names="gene_names",
+            obsm_mapping={
+                "X_umap": ["umap_1", "umap_2"]
+            }
+        )
     """
-    obsm_names = obsm_names or {}
-    varm_names = varm_names or {}
+    # Deprecations
+    if obsm_names is not None:
+        warn(
+            "Argument obsm_names has been deprecated in favour of `obsm_mapping`. "
+            "In 0.9 this will be an error.",
+            FutureWarning,
+        )
+        if obsm_mapping != {}:
+            raise ValueError(
+                "Recieved values for both `obsm_names` and `obsm_mapping`. This is "
+                "ambiguous, only pass `obsm_mapping`."
+            )
+        obsm_mapping = obsm_names
+    if varm_names is not None:
+        warn(
+            "Argument varm_names has been deprecated in favour of `varm_mapping`. "
+            "In 0.9 this will be an error.",
+            FutureWarning,
+        )
+        if varm_mapping != {}:
+            raise ValueError(
+                "Recieved values for both `varm_names` and `varm_mapping`. This is "
+                "ambiguous, only pass `varm_mapping`."
+            )
+        varm_mapping = varm_names
 
     filename = fspath(filename)  # allow passing pathlib.Path objects
     from loompy import connect
@@ -231,8 +277,8 @@ def read_loom(
                 )
 
         # TODO: Figure out the singleton obs elements
-        obs, obsm = _fmt_loom_axis_attrs(dict(lc.col_attrs), obs_names, obsm_names)
-        var, varm = _fmt_loom_axis_attrs(dict(lc.row_attrs), var_names, varm_names)
+        obs, obsm = _fmt_loom_axis_attrs(dict(lc.col_attrs), obs_names, obsm_mapping)
+        var, varm = _fmt_loom_axis_attrs(dict(lc.row_attrs), var_names, varm_mapping)
 
         uns = {}
         if cleanup:

--- a/anndata/_io/read.py
+++ b/anndata/_io/read.py
@@ -191,7 +191,7 @@ def read_loom(
     Beware that you have to explicitly state when you want to read the file as
     sparse data.
 
-        Parameters
+    Parameters
     ----------
     filename
         The filename.

--- a/anndata/_io/write.py
+++ b/anndata/_io/write.py
@@ -82,9 +82,13 @@ def write_csvs(
 def write_loom(filename: PathLike, adata: AnnData, write_obsm_varm: bool = False):
     filename = Path(filename)
     row_attrs = {k: np.array(v) for k, v in adata.var.to_dict("list").items()}
-    row_attrs["var_names"] = adata.var_names.values
+    row_names = adata.var_names
+    row_dim = row_names.name if row_names.name is not None else "var_names"
+    row_attrs[row_dim] = row_names.values
     col_attrs = {k: np.array(v) for k, v in adata.obs.to_dict("list").items()}
-    col_attrs["obs_names"] = adata.obs_names.values
+    col_names = adata.obs_names
+    col_dim = col_names.name if col_names.name is not None else "obs_names"
+    col_attrs[col_dim] = col_names.values
 
     if adata.X is None:
         raise ValueError("loompy does not accept empty matrices as data")

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -348,18 +348,26 @@ def test_changed_obs_var_names(tmp_path, diskfmt):
 @pytest.mark.parametrize("varm_names", [{}, dict(X_composed2=["vanno3", "vanno4"])])
 def test_readwrite_loom(typ, obsm_names, varm_names, tmp_path):
     X = typ(X_list)
+    obs_dim = "meaningful_obs_dim_name"
+    var_dim = "meaningful_var_dim_name"
     adata_src = ad.AnnData(X, obs=obs_dict, var=var_dict, uns=uns_dict)
+    adata_src.obs_names.name = obs_dim
+    adata_src.var_names.name = var_dim
     adata_src.obsm["X_a"] = np.zeros((adata_src.n_obs, 2))
     adata_src.varm["X_b"] = np.zeros((adata_src.n_vars, 3))
+
     adata_src.write_loom(tmp_path / "test.loom", write_obsm_varm=True)
 
     adata = ad.read_loom(
         tmp_path / "test.loom",
         sparse=typ is csr_matrix,
         obsm_names=obsm_names,
+        obs_names=obs_dim,
         varm_names=varm_names,
+        var_names=var_dim,
         cleanup=True,
     )
+
     if isinstance(X, np.ndarray):
         assert np.allclose(adata.X, X)
     else:
@@ -374,6 +382,8 @@ def test_readwrite_loom(typ, obsm_names, varm_names, tmp_path):
         assert k in adata.obsm_keys() and adata.obsm[k].shape[1] == len(v)
     for k, v in varm_names.items():
         assert k in adata.varm_keys() and adata.varm[k].shape[1] == len(v)
+    assert adata.obs_names.name == obs_dim
+    assert adata.var_names.name == var_dim
 
 
 def test_read_csv():

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -7,6 +7,7 @@ On master
 .. rubric:: New features
 
 - Added :meth:`anndata.AnnData.to_memory` for returning an in memory object from a backed one :pr:`470` :pr:`542` :smaller:`V Bergen` :smaller:`I Virshup`
+- :meth:`anndata.AnnData.write_loom` now writes `obs_names` and `var_names` using the `Index`'s `.name` attribute, if set :pr:`538` :smaller:`I Virshup`
 
 .. rubric:: Bug fixes
 
@@ -17,6 +18,12 @@ On master
 - Fixed handling of compression key word arguments :pr:`536` :smaller:`I Virshup`
 - Fixed copying a backed `AnnData` from changing which file the original object points at :pr:`533` :smaller:`ilia-kats`
 - Fixed a bug where calling `AnnData.concatenate` an `AnnData` with no variables would error :pr:`537` :smaller:`I Virshup`
+
+.. rubric:: Deprecations
+
+- Passing positional arguments to :func:`anndata.read_loom` besides the path is now deprecated :pr:`538` :smaller:`I Virshup`
+- :func:`anndata.read_loom` arguments `obsm_names` and `varm_names` are now deprecated in favour of `obsm_mapping` and `varm_mapping` :pr:`538` :smaller:`I Virshup`
+
 
 0.7.5 :small:`2020-11-12`
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #509
Supersedes #508

Also did a little bit of consolidation in `read_loom`. 

## TODO:

- [ ] ~~Figure out what's going on with singleton values in `read_loom` (e.g. `cleanup=True` code)~~
  - These are uniform arrays stored in loom. Not sure why we have an argument to remove these, but it's opt-in so leaving it for now.
- [x] Release note
