### PR TITLE
To memory review pass

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -609,7 +609,6 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             X = self.file["X"]
             if isinstance(X, h5py.Group):
                 X = SparseDataset(X)
-            # TODO: This should get replaced/ handled elsewhere
             # This is so that we can index into a backed dense dataset with
             # indices that aren’t strictly increasing
             if self.is_view:

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -611,18 +611,8 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
             # TODO: This should get replaced/ handled elsewhere
             # This is so that we can index into a backed dense dataset with
             # indices that aren’t strictly increasing
-            if self.is_view and isinstance(X, h5py.Dataset):
-                ordered = [self._oidx, self._vidx]  # this will be mutated
-                rev_order = [slice(None), slice(None)]
-                for axis, axis_idx in enumerate(ordered.copy()):
-                    if isinstance(axis_idx, np.ndarray) and axis_idx.dtype.type != bool:
-                        order = np.argsort(axis_idx)
-                        ordered[axis] = axis_idx[order]
-                        rev_order[axis] = np.argsort(order)
-                # from hdf5, then to real order
-                X = X[tuple(ordered)][tuple(rev_order)]
-            elif self.is_view:
-                X = X[self._oidx, self._vidx]
+            if self.is_view:
+                X = _subset(X, (self._oidx, self._vidx))
         elif self.is_view:
             X = as_view(
                 _subset(self._adata_ref.X, (self._oidx, self._vidx)),

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1429,7 +1429,14 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
     def _mutated_copy(self, **kwargs):
         """Creating AnnData with attributes optionally specified via kwargs."""
+        if self.isbacked:
+            if "X" not in kwargs or (self.raw is not None and "raw" not in kwargs):
+                raise NotImplementedError(
+                    "This function does not currently handle backed objects "
+                    "internally, this should be dealt with before."
+                )
         new = {}
+
         for key in ["obs", "var", "obsm", "varm", "obsp", "varp", "layers"]:
             if key in kwargs:
                 new[key] = kwargs[key]
@@ -1437,7 +1444,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 new[key] = getattr(self, key).copy()
         if "X" in kwargs:
             new["X"] = kwargs["X"]
-        elif self.is_backed:
+        else:
             new["X"] = self.X.copy()
         if "uns" in kwargs:
             new["uns"] = kwargs["uns"]
@@ -1451,16 +1458,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         if "raw" in kwargs:
             new["raw"] = kwargs["raw"]
         elif self.raw is not None:
-            if self.isbacked:
-                new["raw"] = self.raw.to_adata().to_memory()
-            else:
-                new["raw"] = self.raw.copy()
-        # kwargs["raw"] = kwargs.pop("raw", None)
-        # if self.raw is not None:
-        #     if self.isbacked:
-        #         warnings.warn("Dropping .raw attribute when loading into memory mode.")
-        #     else:
-        #         kwargs["raw"] = self.raw.copy()
+            new["raw"] = self.raw.copy()
         new["dtype"] = new["X"].dtype
         return AnnData(**new)
 

--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1474,10 +1474,19 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         return AnnData(**new)
 
     def to_memory(self) -> "AnnData":
-        """Loading AnnData object into memory."""
+        """Load backed AnnData object into memory.
+
+        Example
+        -------
+
+        .. code:: python
+
+            import anndata
+            backed = anndata.read_h5ad("file.h5ad", backed="r")
+            mem = backed[backed.obs["cluster"] == "a", :].to_memory()
+        """
         if not self.isbacked:
-            warnings.warn("Object is already in memory.")
-            adata = self
+            raise ValueError("Object is already in memory.")
         else:
             elems = {"X": to_memory(self.X)}
             if self.raw is not None:

--- a/anndata/_core/index.py
+++ b/anndata/_core/index.py
@@ -140,6 +140,7 @@ def _subset_df(df: pd.DataFrame, subset_idx: Index):
     return df.iloc[subset_idx]
 
 
+# Registration for SparseDataset occurs in sparse_dataset.py
 @_subset.register(h5py.Dataset)
 def _subset_dataset(d, subset_idx):
     if not isinstance(subset_idx, tuple):

--- a/anndata/_core/raw.py
+++ b/anndata/_core/raw.py
@@ -65,7 +65,7 @@ class Raw:
         if self._adata.is_view:
             # TODO: As noted above, implement views of raw
             #       so we can know if we need to subset by var
-            return X[self._adata._oidx, slice(None)]
+            return _subset(X, (self._adata._oidx, slice(None)))
         else:
             return X
 

--- a/anndata/_core/sparse_dataset.py
+++ b/anndata/_core/sparse_dataset.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     _cs_matrix = ss.spmatrix
 
-from .index import unpack_index, Index
+from .index import unpack_index, Index, _subset
 
 
 class BackedFormat(NamedTuple):
@@ -372,3 +372,8 @@ class SparseDataset:
         mtx.indices = self.group["indices"][...]
         mtx.indptr = self.group["indptr"][...]
         return mtx
+
+
+@_subset.register(SparseDataset)
+def subset_sparsedataset(d, subset_idx):
+    return d[subset_idx]

--- a/anndata/tests/test_hdf5_backing.py
+++ b/anndata/tests/test_hdf5_backing.py
@@ -198,7 +198,6 @@ def test_backed_raw_subset(tmp_path, array_type, subset_func, subset_func2):
     backed_v = backed_adata[obs_idx, var_idx]
     assert backed_v.is_view
     mem_v = mem_adata[obs_idx, var_idx]
-    print(type(obs_idx), obs_idx, type(var_idx), var_idx)
 
     # Value equivalent
     assert_equal(mem_v, backed_v)
@@ -210,12 +209,8 @@ def test_backed_raw_subset(tmp_path, array_type, subset_func, subset_func2):
     ### Write from backed view ###
     backed_v.write_h5ad(final_pth)
     final_adata = ad.read_h5ad(final_pth)
-    # TODO: Figure out why this doesn’t work if I don’t copy
-    assert_equal(mem_v.copy(), final_adata)
 
-    # todo: breaks when removing this line, b/c backed_v.X is not accessible
-    backed_v = ad.read_h5ad(backed_pth, backed="r")[obs_idx, var_idx]
-    del final_adata.raw  # .raw is dropped when loading backed into memory.
+    assert_equal(mem_v, final_adata)
     assert_equal(final_adata, backed_v.to_memory())  # assert loading into memory
 
 

--- a/anndata/tests/test_hdf5_backing.py
+++ b/anndata/tests/test_hdf5_backing.py
@@ -230,6 +230,11 @@ def test_to_memory_full(tmp_path, array_type):
     backed_adata = ad.read_h5ad(backed_pth, backed="r")
     assert_equal(mem_adata, backed_adata.to_memory())
 
+    # Test that raw can be removed
+    del backed_adata.raw
+    del mem_adata.raw
+    assert_equal(mem_adata, backed_adata.to_memory())
+
 
 def test_to_memory_error():
     adata = gen_adata((5, 3))

--- a/anndata/tests/test_hdf5_backing.py
+++ b/anndata/tests/test_hdf5_backing.py
@@ -231,6 +231,12 @@ def test_to_memory_full(tmp_path, array_type):
     assert_equal(mem_adata, backed_adata.to_memory())
 
 
+def test_to_memory_error():
+    adata = gen_adata((5, 3))
+    with pytest.raises(ValueError):
+        adata.to_memory()
+
+
 def test_double_index(adata, backing_h5ad):
     adata.filename = backing_h5ad
     with pytest.raises(ValueError):

--- a/anndata/tests/test_helpers.py
+++ b/anndata/tests/test_helpers.py
@@ -122,6 +122,20 @@ def test_assert_equal_raw():
         assert_equal(orig, to_compare)
 
 
+def test_assert_equal_raw_presence():
+    # This was causing some testing issues during
+    # https://github.com/theislab/anndata/pull/542
+    a = gen_adata((10, 20))
+    b = a.copy()
+    a.raw = a.copy()
+    assert b.raw is None
+
+    with pytest.raises(AssertionError):
+        assert_equal(a, b)
+    with pytest.raises(AssertionError):
+        assert_equal(b, a)
+
+
 # TODO: Should views be equal to actual?
 # Should they not be if an exact comparison is made?
 def test_assert_equal_aligned_mapping():

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -4,6 +4,10 @@
 On master
 ~~~~~~~~~
 
+.. rubric:: New features
+
+- Added :meth:`anndata.AnnData.to_memory` for returning an in memory object from a backed one :pr:`470` :pr:`542` :smaller:`V Bergen` :smaller:`I Virshup`
+
 .. rubric:: Bug fixes
 
 - Fixed bug where `np.str_` column names errored at write time :pr:`457` :smaller:`I Virshup`
@@ -12,7 +16,7 @@ On master
 - Fixed null values being converted to strings when strings are converted to categorical :pr:`529` :smaller:`I Virshup`
 - Fixed handling of compression key word arguments :pr:`536` :smaller:`I Virshup`
 - Fixed copying a backed `AnnData` from changing which file the original object points at :pr:`533` :smaller:`ilia-kats`
-- Fixed a bug where calling `AnnData.concatenate` an `AnnData` with no variables would error :pr:`537`
+- Fixed a bug where calling `AnnData.concatenate` an `AnnData` with no variables would error :pr:`537` :smaller:`I Virshup`
 
 0.7.5 :small:`2020-11-12`
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
A bit of a belated review on the `.to_memory` method. Main changes:

* Renamed and simplified internal function a bit (`_create_anndata` -> `_mutated_copy`)
* Made `to_memory` work with `raw`
* Made `to_memory` work with dense backed arrays
* More tests
* Centralized subsetting of backed arrays (added `h5py.Dataset` and `SparseDataset` methods to `_subset`)
* Fixed bug in `assert_equals` where if the first argument didn't have raw, the second arguments `raw` wasn't checked

Could probably use a benchmark run.

TODO

- [x] Probably make `.to_memory` error if the object isn't backed.
- [x] Change log