### PR TITLE
Simplify handling of .uns in views

### DIFF
--- a/anndata/compat/_overloaded_dict.py
+++ b/anndata/compat/_overloaded_dict.py
@@ -1,6 +1,6 @@
 from collections.abc import MutableMapping
 from functools import partial
-from typing import Any, Callable, List, Mapping, Optional
+from typing import Any, Callable, List, Mapping, Optional, Union
 from warnings import warn
 from weakref import proxy
 
@@ -198,9 +198,9 @@ def _neighbors_getter(ovld: OverloadedDict, key, adata: "AnnData"):
     )
 
 
-def _overloaded_uns(adata: "AnnData") -> OverloadedDict:
+def _overloaded_uns(adata: "AnnData", uns: Union[dict, "DictView"]) -> OverloadedDict:
     return OverloadedDict(
-        adata._uns,
+        uns,
         overloaded={
             "neighbors": KeyOverload(
                 "neighbors",

--- a/anndata/tests/test_uns.py
+++ b/anndata/tests/test_uns.py
@@ -1,32 +1,49 @@
 import numpy as np
 import pandas as pd
 
+import pytest
+
 from anndata import AnnData
+from anndata.tests.helpers import assert_equal
 
 
 def test_uns_color_subset():
     # Tests for https://github.com/theislab/anndata/issues/257
-    obs = pd.DataFrame(index=[f"cell{i}" for i in range(5)])
-    obs["cat1"] = pd.Series(list("aabcd"), index=obs.index, dtype="category")
-    obs["cat2"] = pd.Series(list("aabbb"), index=obs.index, dtype="category")
-    uns = dict(
-        cat1_colors=["red", "green", "blue"],
-        cat2_colors=["red", "green", "blue"],
+    obs = pd.DataFrame(
+        {
+            "cat1": pd.Categorical(list("aabcd")),
+            "cat2": pd.Categorical(list("aabbb")),
+        },
+        index=[f"cell{i}" for i in range(5)],
     )
 
-    adata = AnnData(np.ones((5, 5)), obs=obs, uns=uns)
+    # If number of categories does not match number of colors, they should be reset
+    wrong_color_length_adata = AnnData(
+        np.ones((5, 5)),
+        obs=obs,
+        uns={
+            "cat1_colors": ["red", "green", "blue"],
+            "cat2_colors": ["red", "green", "blue"],
+        },
+    )
+    v = wrong_color_length_adata[:, [0, 1]]
 
-    # If number of categories does not match number of colors,
-    # they should be reset
-    v = adata[:, [0, 1]]
     assert "cat1_colors" not in v.uns
     assert "cat2_colors" not in v.uns
 
     # Otherwise the colors should still match after reseting
-    cat1_colors = ["red", "green", "blue", "yellow"]
-    adata.uns["cat1_colors"] = cat1_colors.copy()
-    v = adata[[0, 1], :]
-    assert len(v.uns["cat1_colors"]) == 1
-    assert v.uns["cat1_colors"][0] == "red"
+    cat1_colors = np.array(["red", "green", "blue", "yellow"], dtype=object)
+    adata = AnnData(np.ones((5, 5)), obs=obs, uns={"cat1_colors": cat1_colors.copy()})
+
+    for color, idx in [("red", [0, 1]), ("green", [2]), ("blue", [3]), ("yellow", [4])]:
+        v = adata[idx, :]
+        assert len(v.uns["cat1_colors"]) == 1
+        assert v.uns["cat1_colors"][0] == color
+
+        c = v.copy()
+        assert_equal(v.uns, c.uns, elem_name="uns")
+        with pytest.raises(AssertionError):
+            assert_equal(adata.uns, c.uns, elem_name="uns")
+
     # But original object should not change
-    assert list(adata.uns["cat1_colors"]) == cat1_colors
+    assert list(adata.uns["cat1_colors"]) == list(cat1_colors)

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -478,3 +478,11 @@ def test_view_retains_ndarray_subclass():
 
     assert isinstance(view.obsm["foo"], NDArraySubclass)
     assert view.obsm["foo"].shape == (5, 5)
+
+
+def test_modify_uns_in_copy():
+    # https://github.com/theislab/anndata/issues/571
+    adata = ad.AnnData(np.ones((5, 5)), uns={"parent": {"key": "value"}})
+    adata_copy = adata[:3].copy()
+    adata_copy.uns["parent"]["key"] = "new_value"
+    assert adata.uns["parent"]["key"] != adata_copy.uns["parent"]["key"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,10 @@ napoleon_use_param = True
 napoleon_custom_sections = [("Params", "Parameters")]
 todo_include_todos = False
 nitpicky = True  # Report broken links
+nitpick_ignore = [
+    ("py:meth", "pandas.DataFrame.iloc"),
+    ("py:meth", "pandas.DataFrame.loc"),
+]
 suppress_warnings = ["ref.citation"]
 
 
@@ -70,9 +74,9 @@ def setup(app: Sphinx):
 
 
 intersphinx_mapping = dict(
-    h5py=("http://docs.h5py.org/en/latest/", None),
+    h5py=("https://docs.h5py.org/en/latest/", None),
     loompy=("https://linnarssonlab.org/loompy/", None),
-    numpy=("https://docs.scipy.org/doc/numpy/", None),
+    numpy=("https://numpy.org/doc/stable/", None),
     pandas=("https://pandas.pydata.org/pandas-docs/stable/", None),
     python=("https://docs.python.org/3", None),
     scipy=("https://docs.scipy.org/doc/scipy/reference/", None),

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -1,6 +1,13 @@
 .. role:: small
 .. role:: smaller
 
+On master :small:`the future`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. rubric:: Bug fixes
+
+- Fixed issue with `.uns` sub-dictionaries being referenced by copies :pr:`576` :smaller:`I Virshup`
+
 0.7.6 :small:`11 April, 2021`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fixes #571

Basically, `uns` has special casing for views around the old neighbor structure and color handling. This, plus fixes for other issues ended up having deleterious solutions. Handling of `.uns` in views should be simplified now. `._uns` should just be a `dict`, wrapping with overloaded keys and view behaviour is done at access time (so there is no longer a circular reference). This could be simplified further with a new way of storing colors and once we drop the old neighbors backwards compatibility.

- [x] Release note
- [x] Run `copy` benchmarks