### PR TITLE
Fix propagation of ImportError for `write_zarr`

### DIFF
--- a/anndata/_io/write.py
+++ b/anndata/_io/write.py
@@ -14,15 +14,22 @@ from . import WriteWarning
 # Exports
 from .h5ad import write_h5ad as _write_h5ad
 
-try:
-    from .zarr import write_zarr
-except ImportError as e:  # noqa: F841  # TODO: Is there a better way?
-
-    def write_zarr(*_, **__):
-        raise e
-
-
 logger = get_logger(__name__)
+
+
+def load_write_zarr():
+    try:
+        from .zarr import write_zarr
+    except ImportError as e:
+        error = e
+
+        def write_zarr(*_, **__):
+            raise error
+
+    return write_zarr
+
+
+write_zarr = load_write_zarr()
 
 
 def write_csvs(

--- a/anndata/_io/write.py
+++ b/anndata/_io/write.py
@@ -18,7 +18,7 @@ from ..utils import import_function
 
 logger = get_logger(__name__)
 
-write_zarr = import_function('anndata._io.zarr', 'write_zarr')
+write_zarr = import_function("anndata._io.zarr", "write_zarr")
 
 
 def write_csvs(

--- a/anndata/_io/write.py
+++ b/anndata/_io/write.py
@@ -14,22 +14,11 @@ from . import WriteWarning
 # Exports
 from .h5ad import write_h5ad as _write_h5ad
 
+from ..utils import import_function
+
 logger = get_logger(__name__)
 
-
-def load_write_zarr():
-    try:
-        from .zarr import write_zarr
-    except ImportError as e:
-        error = e
-
-        def write_zarr(*_, **__):
-            raise error
-
-    return write_zarr
-
-
-write_zarr = load_write_zarr()
+write_zarr = import_function('anndata._io.zarr', 'write_zarr')
 
 
 def write_csvs(

--- a/anndata/tests/test_utils.py
+++ b/anndata/tests/test_utils.py
@@ -4,10 +4,7 @@ from itertools import repeat
 import pytest
 
 import anndata as ad
-from anndata.utils import (
-    make_index_unique,
-    import_function
-)
+from anndata.utils import import_function, make_index_unique
 from anndata.tests.helpers import gen_typed_df
 
 
@@ -62,7 +59,7 @@ def test_import_function_no_import_error():
     A TypeError is expected if the `write_zarr` function is imported
     correctly because `write_zarr` requires two arguments.
     """
-    with pytest.raises(TypeError) as e_info:
+    with pytest.raises(TypeError):
         write_zarr = import_function("anndata._io.zarr", "write_zarr")
         write_zarr()
 
@@ -72,7 +69,7 @@ def test_import_function_missing_module():
     A ModuleNotFoundError is expected because there is no module called
     `should_not_exist`.
     """
-    with pytest.raises(ModuleNotFoundError) as e_info:
+    with pytest.raises(ModuleNotFoundError):
         some_function = import_function("should_not_exist", "some_function")
         some_function()
 
@@ -82,6 +79,6 @@ def test_import_function_missing_function():
     An AttributeError is expected because the `anndata` module exists but it
     does not export a function called `some_function`.
     """
-    with pytest.raises(AttributeError) as e_info:
+    with pytest.raises(AttributeError):
         some_function = import_function("anndata", "some_function")
         some_function()

--- a/anndata/tests/test_utils.py
+++ b/anndata/tests/test_utils.py
@@ -4,7 +4,10 @@ from itertools import repeat
 import pytest
 
 import anndata as ad
-from anndata.utils import make_index_unique
+from anndata.utils import (
+    make_index_unique,
+    import_function
+)
 from anndata.tests.helpers import gen_typed_df
 
 
@@ -52,3 +55,33 @@ def test_adata_unique_indices():
 
     pd.testing.assert_index_equal(v.obsm["df"].index, v.obs_names)
     pd.testing.assert_index_equal(v.varm["df"].index, v.var_names)
+
+
+def test_import_function_no_import_error():
+    """/
+    A TypeError is expected if the `write_zarr` function is imported
+    correctly because `write_zarr` requires two arguments.
+    """
+    with pytest.raises(TypeError) as e_info:
+        write_zarr = import_function("anndata._io.zarr", "write_zarr")
+        write_zarr()
+
+
+def test_import_function_missing_module():
+    """/
+    A ModuleNotFoundError is expected because there is no module called
+    `should_not_exist`.
+    """
+    with pytest.raises(ModuleNotFoundError) as e_info:
+        some_function = import_function("should_not_exist", "some_function")
+        some_function()
+
+
+def test_import_function_missing_function():
+    """/
+    An AttributeError is expected because the `anndata` module exists but it
+    does not export a function called `some_function`.
+    """
+    with pytest.raises(AttributeError) as e_info:
+        some_function = import_function("anndata", "some_function")
+        some_function()

--- a/anndata/utils.py
+++ b/anndata/utils.py
@@ -225,25 +225,25 @@ class DeprecationMixinMeta(type):
         ]
 
 
-def import_function(module, name):
+def import_function(module: str, name: str):
     """\
     Try to import function from module. If the module is not installed or
     function is not part of the module, it returns a dummy function that raises
     the respective import error once the function is called. This could be a
     ModuleNotFoundError if the module is missing or an AttributeError if the
     module is installed but the function is not exported by it.
+
+    Params
+    -------
+    module
+        Module to import from. Can be nested, e.g. "sklearn.utils".
+    name
+        Name of function to import from module.
     """
     try:
         module = __import__(module, fromlist=[name])
-        try:
-            func = getattr(module, name)
-        except AttributeError as e:
-            error = e
-
-            def func(*_, **__):
-                raise error
-             
-    except ImportError as e:
+        func = getattr(module, name)
+    except (ImportError, AttributeError) as e:
         error = e
 
         def func(*_, **__):

--- a/anndata/utils.py
+++ b/anndata/utils.py
@@ -223,3 +223,30 @@ class DeprecationMixinMeta(type):
             for item in type.__dir__(cls)
             if not is_deprecated(getattr(cls, item, None))
         ]
+
+
+def import_function(module, name):
+    """\
+    Try to import function from module. If the module is not installed or
+    function is not part of the module, it returns a dummy function that raises
+    the respective import error once the function is called. This could be a
+    ModuleNotFoundError if the module is missing or an AttributeError if the
+    module is installed but the function is not exported by it.
+    """
+    try:
+        module = __import__(module, fromlist=[name])
+        try:
+            func = getattr(module, name)
+        except AttributeError as e:
+            error = e
+
+            def func(*_, **__):
+                raise error
+             
+    except ImportError as e:
+        error = e
+
+        def func(*_, **__):
+            raise error
+
+    return func

--- a/anndata/utils.py
+++ b/anndata/utils.py
@@ -1,6 +1,6 @@
 import warnings
 from functools import wraps, singledispatch
-from typing import Mapping, Any, Sequence, Union
+from typing import Mapping, Any, Sequence, Union, Callable
 
 import h5py
 import pandas as pd
@@ -225,7 +225,7 @@ class DeprecationMixinMeta(type):
         ]
 
 
-def import_function(module: str, name: str):
+def import_function(module: str, name: str) -> Callable:
     """\
     Try to import function from module. If the module is not installed or
     function is not part of the module, it returns a dummy function that raises
@@ -240,8 +240,9 @@ def import_function(module: str, name: str):
     name
         Name of function to import from module.
     """
+    from importlib import import_module
     try:
-        module = __import__(module, fromlist=[name])
+        module = import_module(module)
         func = getattr(module, name)
     except (ImportError, AttributeError) as e:
         error = e

--- a/anndata/utils.py
+++ b/anndata/utils.py
@@ -241,6 +241,7 @@ def import_function(module: str, name: str) -> Callable:
         Name of function to import from module.
     """
     from importlib import import_module
+
     try:
         module = import_module(module)
         func = getattr(module, name)

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -2,7 +2,7 @@
 .. role:: smaller
 
 On `master` :small:`the future`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. rubric:: Bug fixes
 

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -1,6 +1,13 @@
 .. role:: small
 .. role:: smaller
 
+0.7.7 :small:`21 June, 2021`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. rubric:: Bug fixes
+
+- Fixed propagation of import error when importing `write_zarr` but not all dependencies are installed :pr:`579` :smaller:`R Hillje` :smaller:`I Virshup`
+
 0.7.6 :small:`11 April, 2021`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -1,12 +1,12 @@
 .. role:: small
 .. role:: smaller
 
-0.7.7 :small:`21 June, 2021`
+On `master` :small:`the future`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. rubric:: Bug fixes
 
-- Fixed propagation of import error when importing `write_zarr` but not all dependencies are installed :pr:`579` :smaller:`R Hillje` :smaller:`I Virshup`
+- Fixed propagation of import error when importing `write_zarr` but not all dependencies are installed :pr:`579` :smaller:`R Hillje`
 
 0.7.6 :small:`11 April, 2021`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
See [issue #578](https://github.com/theislab/anndata/issues/578).

This fixes the propagation of the import error for the `write_zarr` function when it cannot be imported, e.g. because dependencies are not available.