### PR TITLE
Switch to Sphinx 4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ doc = [
     'sphinx-rtd-theme',
     'sphinx-autodoc-typehints>=1.11.0',
     'sphinx_issues',
-    'scanpydoc>=0.7.1',
+    'scanpydoc>=0.7.3',
     'typing_extensions; python_version < "3.8"',
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
     'docutils',
 ]
 doc = [
-    'sphinx>=4.0,<4.1',
+    'sphinx>=4.1',
     'sphinx-rtd-theme',
     'sphinx-autodoc-typehints>=1.11.0',
     'sphinx_issues',


### PR DESCRIPTION
Makes sure people don’t need `qualname_overrides` anymore