### PR TITLE
Switch stable docs to sphinx 4.1

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
 sphinx:
   configuration: docs/conf.py
 python:
-  version: 3.6
+  version: 3.8
   install:
   - method: pip
     path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,26 +64,7 @@ nitpicky = True  # Report broken links
 suppress_warnings = ["ref.citation"]
 
 
-def work_around_issue_6785():
-    """See https://github.com/sphinx-doc/sphinx/issues/6785"""
-    from docutils.parsers.rst import directives
-    from sphinx.ext import autodoc
-    from sphinx.domains.python import PyAttribute
-
-    # check if the code changes on the sphinx side and we can remove this
-    assert autodoc.PropertyDocumenter.directivetype == "method"
-    autodoc.PropertyDocumenter.directivetype = "attribute"
-
-    def get_signature_prefix(self, sig: str) -> str:
-        # TODO: abstract attributes
-        return "property " if "property" in self.options else ""
-
-    PyAttribute.option_spec["property"] = directives.flag
-    PyAttribute.get_signature_prefix = get_signature_prefix
-
-
 def setup(app: Sphinx):
-    work_around_issue_6785()
     # Don’t allow broken links. DO NOT CHANGE THIS LINE, fix problems instead.
     app.warningiserror = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,11 +55,11 @@ dev = [
 ]
 doc = [
     # Sphinx 2 has nicer looking sections
-    'sphinx>=2.0.1',
+    'sphinx>=4.1',
     'sphinx-rtd-theme',
     'sphinx-autodoc-typehints>=1.11.0',
     'sphinx_issues',
-    'scanpydoc>=0.5',
+    'scanpydoc>=0.7.3',
     'typing_extensions; python_version < "3.8"',
 ]
 test = [


### PR DESCRIPTION
Makes sure people linking against our stable docs don’t need `qualname_overrides` anymore

Same as #593 is for master