### PR TITLE
references to the same object should be equal

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -591,10 +591,13 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
 
     def __eq__(self, other):
         """Equality testing"""
-        raise NotImplementedError(
-            "Equality comparisons are not supported for AnnData objects, "
-            "instead compare the desired attributes."
-        )
+        if self is other:
+            return True
+        else:
+            raise NotImplementedError(
+                "Equality comparisons are not supported for AnnData objects, "
+                "instead compare the desired attributes."
+            )
 
     @property
     def shape(self) -> Tuple[int, int]:

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -428,6 +428,7 @@ def test_n_obs():
 def test_equality_comparisons():
     adata1 = AnnData(np.array([[1, 2], [3, 4], [5, 6]]))
     adata2 = AnnData(np.array([[1, 2], [3, 4], [5, 6]]))
+    assert adata1 == adata1
     with pytest.raises(NotImplementedError):
         adata1 == adata1
     with pytest.raises(NotImplementedError):

--- a/anndata/tests/test_base.py
+++ b/anndata/tests/test_base.py
@@ -430,8 +430,6 @@ def test_equality_comparisons():
     adata2 = AnnData(np.array([[1, 2], [3, 4], [5, 6]]))
     assert adata1 == adata1
     with pytest.raises(NotImplementedError):
-        adata1 == adata1
-    with pytest.raises(NotImplementedError):
         adata1 == adata2
     with pytest.raises(NotImplementedError):
         adata1 != adata2


### PR DESCRIPTION
This fixes an issue with #272 where two references of the same object are not equal. Strangely we need this in scvi-tools for pytorch lightning related reasons.