### PR TITLE
Pin sphinx below 4.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
     'docutils',
 ]
 doc = [
-    'sphinx>=4.1',
+    'sphinx>=4.1,<4.2',
     'sphinx-rtd-theme',
     'sphinx-autodoc-typehints>=1.11.0',
     'sphinx_issues',


### PR DESCRIPTION
Sphinx 4.2.0 seems to be running into issues resolving types. 

```
Warning, treated as error:
/Users/isaac/github/anndata/anndata/_core/anndata.py:docstring of anndata.AnnData.layers::py:class reference target not found: anndata._core.aligned_mapping.Layers
```

I believe this is connected with sphinx-autodoc-typehints but am not completely sure. This should get doc builds working again for now.
