### PR TITLE
scipy 1.7.2 compat for SparseDataset

### DIFF
--- a/anndata/_core/sparse_dataset.py
+++ b/anndata/_core/sparse_dataset.py
@@ -362,7 +362,7 @@ class SparseDataset:
         mtx = format_class(self.shape, dtype=self.dtype)
         mtx.data = self.group["data"]
         mtx.indices = self.group["indices"]
-        mtx.indptr = self.group["indptr"]
+        mtx.indptr = self.group["indptr"][:]
         return mtx
 
     def to_memory(self) -> ss.spmatrix:

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -9,6 +9,7 @@ On `master` :small:`the future`
 - Fixed propagation of import error when importing `write_zarr` but not all dependencies are installed :pr:`579` :smaller:`R Hillje`
 - Fixed issue with `.uns` sub-dictionaries being referenced by copies :pr:`576` :smaller:`I Virshup`
 - Fixed out-of-bounds integer indices not raising :class:`IndexError` :pr:`630` :smaller:`M Klein`
+- Fixed backed `SparseDataset` indexing with scipy 1.7.2 :pr:`638` :smaller:`I Virshup`
 
 
 0.7.6 :small:`11 April, 2021`


### PR DESCRIPTION
Fixes #637

Loads `indptr` into memory to avoid errors being thrown due to hdf5 only allowing in-order indexing. I believe this was effectively happening before anyways, so performance shouldn't be hit much.