### PR TITLE
first attempt to support awkward arrays

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1846,7 +1846,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
         if "obsm" in key:
             obsm = self._obsm
             if (
-                not all([o.shape[0] == self._n_obs for o in obsm.values()])
+                not all([len(o) == self._n_obs for o in obsm.values()])
                 and len(obsm.dim_names) != self._n_obs
             ):
                 raise ValueError(

--- a/anndata/_core/index.py
+++ b/anndata/_core/index.py
@@ -8,6 +8,14 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import spmatrix, issparse
 
+import warnings
+
+try:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        import awkward as ak
+except ImportError:
+    ak = None
 
 Index1D = Union[slice, int, str, np.int64, np.ndarray]
 Index = Union[Index1D, Tuple[Index1D, Index1D], spmatrix]
@@ -138,6 +146,13 @@ def _subset_spmatrix(a: spmatrix, subset_idx: Index):
 @_subset.register(pd.DataFrame)
 def _subset_df(df: pd.DataFrame, subset_idx: Index):
     return df.iloc[subset_idx]
+
+
+@_subset.register(ak.Array)
+def _subset_awkarray(a: ak.Array, subset_idx: Index):
+    if all(isinstance(x, cabc.Iterable) for x in subset_idx):
+        subset_idx = np.ix_(*subset_idx)
+    return a[subset_idx]
 
 
 # Registration for SparseDataset occurs in sparse_dataset.py

--- a/anndata/_core/views.py
+++ b/anndata/_core/views.py
@@ -127,35 +127,6 @@ class AwkwardArrayView(_ViewMixin, ak.Array):
         return ak.copy(self)
 
 
-# class AwkwardArrayView(_SetItemMixin, np.ndarray):
-#     def __new__(
-#         cls,
-#         input_array: Sequence[Any],
-#         view_args: Tuple["anndata.AnnData", str, Tuple[str, ...]] = None,
-#     ):
-#         arr = np.asanyarray(input_array).view(cls)
-
-#         if view_args is not None:
-#             view_args = ElementRef(*view_args)
-#         arr._view_args = view_args
-#         return arr
-
-#     def __array_finalize__(self, obj: Optional[np.ndarray]):
-#         if obj is not None:
-#             self._view_args = getattr(obj, "_view_args", None)
-
-#     def keys(self) -> KeysView[str]:
-#         # it’s a structured array
-#         return self.dtype.names
-
-#     def copy(self, order: str = "C") -> np.ndarray:
-#         # we want a conventional array
-#         return np.array(self)
-
-#     def toarray(self) -> np.ndarray:
-#         return self.copy()
-
-
 @singledispatch
 def as_view(obj, view_args):
     raise NotImplementedError(f"No view type has been registered for {type(obj)}")

--- a/anndata/_core/views.py
+++ b/anndata/_core/views.py
@@ -123,7 +123,7 @@ class DataFrameView(_ViewMixin, pd.DataFrame):
 
 class AwkwardArrayView(_ViewMixin, ak.Array):
     def copy(self, order: str = "C") -> np.ndarray:
-        # we want a conventional array
+        # we want a copy of an akward array
         return ak.copy(self)
 
 


### PR DESCRIPTION
First draft at supporting [awkward arrays](https://awkward-array.org/quickstart.html#).
As discussed with @ivirshup this would be useful for Squidpy @hspitzer and potentially @Zethson EHR project. 

Here's a walkthrough showcasing some basic functionality we could use for sub observation annotations (e.g. spatial coordinates of rna-molecules/segmentations).

<details>
<summary>Details</summary>

```python
import numpy as np
import scanpy as sc
import squidpy as sq
import matplotlib.pyplot as plt
from numpy.random import default_rng
from sklearn.datasets import make_blobs
import awkward as ak

adata = sq.datasets.visium_hne_adata()
adata = adata[:10, :].copy()
adata.obsm["spatial"] = (
    adata.obsm["spatial"] - np.std(adata.obsm["spatial"], 0)
) / np.mean(adata.obsm["spatial"], 0)

# generate data
obs_list = []
rng = default_rng(42)
for idx in adata.obs_names.values:
    coord, _ = make_blobs(
        n_samples=rng.integers(5, 15),
        cluster_std=0.02,
        centers=adata[idx].obsm["spatial"],
        random_state=42,
    )
    obs_list.append(coord)

sub_obs = ak.Array(obs_list)

fig, ax = plt.subplots(1, 2, figsize=(10, 5))
ax[0].set_aspect("equal")
ax[0].scatter(x=adata.obsm["spatial"][:, 0], y=adata.obsm["spatial"][:, 1])
for i in range(adata.shape[0]):
    ax[1].scatter(
        x=sub_obs[i, :, 0],
        y=sub_obs[i, :, 1],
    )
    ax[1].axis("equal")
```

![image](https://user-images.githubusercontent.com/25887487/141678224-ac5f3b9a-bc8c-4042-ba29-8a6991e2f817.png)

```python
adata.obsm["sub_obs"] = sub_obs  # sub_obs is an awkward array
adata_subset = adata[:5]  # let's subset, it also works for `.copy()`

fig, ax = plt.subplots(1, 2, figsize=(10, 5))
ax[0].set_aspect("equal")
ax[0].scatter(
    x=adata_subset.obsm["spatial"][:, 0], y=adata_subset.obsm["spatial"][:, 1]
)
for i in range(adata_subset.shape[0]):
    ax[1].scatter(
        x=adata_subset.obsm["sub_obs"][i, :, 0],
        y=adata_subset.obsm["sub_obs"][i, :, 1],
    )
    ax[1].set_aspect("equal")
```
![image](https://user-images.githubusercontent.com/25887487/141678282-375d423c-5207-46e7-8418-c650584582d0.png)
</details>

What fails atm is `adata.concatenate()` because of errors in reindexing of alternate axis
https://github.com/theislab/anndata/blob/286bc7f207863964cb861f17c96ab24fe0cf72ac/anndata/_core/merge.py#L478

in awkward arrays there is no `shape` attribute so when `array.shape[0]` is needed we can resort to `len(awkward_array)` but for `array.shape[1]` we should (probably) simply skip it and concatenate. In `awkward` it would be like this:

```python
ak.concatenate([sub_obs, sub_obs])
>>> <Array [[[1.25, 0.833], ... [0.697, 1.22]]] type='20 * var * var * float64'>
```