### PR TITLE
Bump minimum python version to 3.7

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -11,11 +11,11 @@ jobs:
     vmImage: 'ubuntu-18.04'
   strategy:
     matrix:
-      Python38:
-        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
         RUN_COVERAGE: yes
-      Python36:
-        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -75,8 +75,8 @@ jobs:
 
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.8'
-    displayName: 'Use Python 3.8'
+      versionSpec: '3.9'
+    displayName: 'Use Python 3.9'
 
   - script: |
       python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
 [project]
 name = "anndata"
 description = "Annotated data."
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 license = {file = "LICENSE"}
 authors = [
     {name = "Philipp Angerer"},
@@ -34,7 +34,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -112,5 +111,5 @@ xfail_strict = true
 
 [tool.black]
 line-length = 88
-target-version = ["py36"]
+target-version = ["py37"]
 exclude = "^/build/.*$"


### PR DESCRIPTION
Bumping the minimum python version to 3.7 for the next major release.

This requirement is already used for scanpy. Annotations should be easier now. Plus we get single dispatch from type annotations now.