### PR TITLE
Warn instead of log

### DIFF
--- a/anndata/_core/views.py
+++ b/anndata/_core/views.py
@@ -2,14 +2,15 @@ from contextlib import contextmanager
 from copy import deepcopy
 from functools import reduce, singledispatch, wraps
 from typing import Any, KeysView, Optional, Sequence, Tuple
+import warnings
 
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_bool_dtype
 from scipy import sparse
 
+from anndata._warnings import ImplicitModificationWarning
 from .access import ElementRef
-from ..logging import anndata_logger as logger
 from ..compat import ZappyArray
 
 
@@ -24,8 +25,11 @@ class _SetItemMixin:
         if self._view_args is None:
             super().__setitem__(idx, value)
         else:
-            logger.warning(
-                f"Trying to set attribute `.{self._view_args.attrname}` of view, copying."
+            warnings.warn(
+                f"Trying to modify attribute `.{self._view_args.attrname}` of view, "
+                "initializing view as actual.",
+                ImplicitModificationWarning,
+                stacklevel=2,
             )
             with self._update() as container:
                 container[idx] = value

--- a/anndata/_warnings.py
+++ b/anndata/_warnings.py
@@ -1,0 +1,13 @@
+class ImplicitModificationWarning(UserWarning):
+    """\
+    Raised whenever initializing an object or assigning a property changes
+    the type of a part of a parameter or the value being assigned.
+
+    Examples
+    ========
+    >>> import pandas as pd
+    >>> adata = AnnData(obs=pd.DataFrame(index=[0, 1, 2]))  # doctest: +SKIP
+    ImplicitModificationWarning: Transforming to str index.
+    """
+
+    pass

--- a/anndata/experimental/multi_files/_anncollection.py
+++ b/anndata/experimental/multi_files/_anncollection.py
@@ -3,6 +3,7 @@ from functools import reduce
 from h5py import Dataset
 import numpy as np
 import pandas as pd
+import warnings
 
 from typing import Dict, Union, Optional, Sequence, Callable
 
@@ -13,7 +14,6 @@ from ..._core.views import _resolve_idx
 from ..._core.merge import concat_arrays, inner_concat_aligned_mapping
 from ..._core.sparse_dataset import SparseDataset
 from ..._core.aligned_mapping import AxisArrays
-from ...logging import anndata_logger as logger
 
 ATTRS = ["obs", "obsm", "layers"]
 
@@ -715,7 +715,7 @@ class AnnCollection(_ConcatViewMixin, _IterateViewMixin):
         self.obs_names = pd.Index(concat_indices)
 
         if not self.obs_names.is_unique:
-            logger.info("Observation names are not unique.")
+            warnings.warn("Observation names are not unique.", UserWarning)
 
         view_attrs = ATTRS.copy()
 

--- a/anndata/logging.py
+++ b/anndata/logging.py
@@ -6,7 +6,6 @@ _previous_memory_usage = None
 anndata_logger = logging.getLogger("anndata")
 # Don’t pass log messages on to logging.root and its handler
 anndata_logger.propagate = False
-anndata_logger.setLevel("INFO")
 anndata_logger.addHandler(logging.StreamHandler())  # Logs go to stderr
 anndata_logger.handlers[-1].setFormatter(logging.Formatter("%(message)s"))
 anndata_logger.handlers[-1].setLevel("INFO")

--- a/anndata/tests/test_raw.py
+++ b/anndata/tests/test_raw.py
@@ -93,7 +93,7 @@ def test_raw_view_rw(adata_raw, backing_h5ad):
     # Make sure it still writes correctly if the object is a view
     adata_raw_view = adata_raw[:, adata_raw.var_names]
     assert_equal(adata_raw_view, adata_raw)
-    with pytest.warns(ImplicitModificationWarning, match="Initializing view as actual"):
+    with pytest.warns(ImplicitModificationWarning, match="initializing view as actual"):
         adata_raw_view.write(backing_h5ad)
     adata_read = ad.read(backing_h5ad)
 

--- a/anndata/utils.py
+++ b/anndata/utils.py
@@ -123,9 +123,11 @@ def make_index_unique(index: pd.Index, join: str = "-"):
 
 def warn_names_duplicates(attr: str):
     names = "Observation" if attr == "obs" else "Variable"
-    logger.info(
+    warnings.warn(
         f"{names} names are not unique. "
-        f"To make them unique, call `.{attr}_names_make_unique`."
+        f"To make them unique, call `.{attr}_names_make_unique`.",
+        UserWarning,
+        stacklevel=2,
     )
 
 

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -10,6 +10,7 @@ On `master` :small:`the future`
 .. rubric:: Features
 
 - Compatability with `h5ad` files written from Julia :pr:`569` :smaller:`I Kats`
+- Many logging messages that should have been warnings are now warnings :pr:`650` :smaller:`I Virshup`
 
 .. rubric:: Documentation
 


### PR DESCRIPTION
There are a number of places where anndata uses logging to warn users about something, when this really should be a warning. Warnings are much easier to test for, and for users to handle. In addition it's really easy to turn a warning into a log!

This also silences some of the pandas `inplace` warnings.