### PR TITLE
Support for nullable `int`s & `bool`s

### DIFF
--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -102,6 +102,11 @@ def equal_array(a, b) -> bool:
     return equal(pd.DataFrame(a), pd.DataFrame(asarray(b)))
 
 
+@equal.register(pd.Series)
+def equal_series(a, b) -> bool:
+    return a.equals(b)
+
+
 @equal.register(sparse.spmatrix)
 def equal_sparse(a, b) -> bool:
     # It's a weird api, don't blame me

--- a/anndata/_io/specs/methods.py
+++ b/anndata/_io/specs/methods.py
@@ -635,6 +635,52 @@ def read_categorical(elem, *, items=None, indices=(slice(None),)):
     )
 
 
+####################
+# Pandas nullables #
+####################
+
+
+@_REGISTRY.register_write(
+    H5Group, pd.arrays.IntegerArray, IOSpec("nullable-integer", "0.1.0")
+)
+@_REGISTRY.register_write(
+    ZarrGroup, pd.arrays.IntegerArray, IOSpec("nullable-integer", "0.1.0")
+)
+@_REGISTRY.register_write(
+    H5Group, pd.arrays.BooleanArray, IOSpec("nullable-boolean", "0.1.0")
+)
+@_REGISTRY.register_write(
+    ZarrGroup, pd.arrays.BooleanArray, IOSpec("nullable-boolean", "0.1.0")
+)
+def write_nullable_integer(f, k, v, dataset_kwargs=MappingProxyType({})):
+    g = f.create_group(k)
+    if v._mask is not None:
+        write_elem(g, "mask", v._mask, dataset_kwargs=dataset_kwargs)
+    write_elem(g, "values", v._data, dataset_kwargs=dataset_kwargs)
+
+
+@_REGISTRY.register_read(H5Group, IOSpec("nullable-integer", "0.1.0"))
+@_REGISTRY.register_read(ZarrGroup, IOSpec("nullable-integer", "0.1.0"))
+def read_nullable_integer(elem):
+    if "mask" in elem:
+        return pd.arrays.IntegerArray(
+            read_elem(elem["values"]), mask=read_elem(elem["mask"])
+        )
+    else:
+        return pd.array(read_elem(elem["values"]))
+
+
+@_REGISTRY.register_read(H5Group, IOSpec("nullable-boolean", "0.1.0"))
+@_REGISTRY.register_read(ZarrGroup, IOSpec("nullable-boolean", "0.1.0"))
+def read_nullable_boolean(elem):
+    if "mask" in elem:
+        return pd.arrays.BooleanArray(
+            read_elem(elem["values"]), mask=read_elem(elem["mask"])
+        )
+    else:
+        return pd.array(read_elem(elem["values"]))
+
+
 ###########
 # Scalars #
 ###########

--- a/anndata/tests/helpers.py
+++ b/anndata/tests/helpers.py
@@ -35,13 +35,22 @@ def gen_typed_df(n, index=None):
     if n > len(letters):
         letters = letters[: n // 2]  # Make sure categories are repeated
     return pd.DataFrame(
-        dict(
-            cat=pd.Categorical(np.random.choice(letters, n)),
-            cat_ordered=pd.Categorical(np.random.choice(letters, n), ordered=True),
-            int64=np.random.randint(-50, 50, n),
-            float64=np.random.random(n),
-            uint8=np.random.randint(255, size=n, dtype="uint8"),
-        ),
+        {
+            "cat": pd.Categorical(np.random.choice(letters, n)),
+            "cat_ordered": pd.Categorical(np.random.choice(letters, n), ordered=True),
+            "int64": np.random.randint(-50, 50, n),
+            "float64": np.random.random(n),
+            "uint8": np.random.randint(255, size=n, dtype="uint8"),
+            "bool": np.random.randint(0, 2, size=n, dtype=bool),
+            "nullable-bool": pd.arrays.BooleanArray(
+                np.random.randint(0, 2, size=n, dtype=bool),
+                mask=np.random.randint(0, 2, size=n, dtype=bool),
+            ),
+            "nullable-int": pd.arrays.IntegerArray(
+                np.random.randint(0, 1000, size=n, dtype=np.int32),
+                mask=np.random.randint(0, 2, size=n, dtype=bool),
+            ),
+        },
         index=index,
     )
 

--- a/anndata/tests/test_inplace_subset.py
+++ b/anndata/tests/test_inplace_subset.py
@@ -27,14 +27,12 @@ def test_inplace_subset_var(matrix_type, subset_func):
     assert_equal(from_view.obs, modified.obs, exact=True)
     assert_equal(from_view.var, modified.var, exact=True)
     for k in from_view.obsm:
-        assert_equal(asarray(from_view.obsm[k]), asarray(modified.obsm[k]), exact=True)
-        assert_equal(asarray(orig.obsm[k]), asarray(modified.obsm[k]), exact=True)
+        assert_equal(from_view.obsm[k], modified.obsm[k], exact=True)
+        assert_equal(orig.obsm[k], modified.obsm[k], exact=True)
     for k in from_view.varm:
-        assert_equal(asarray(from_view.varm[k]), asarray(modified.varm[k]), exact=True)
+        assert_equal(from_view.varm[k], modified.varm[k], exact=True)
     for k in from_view.layers:
-        assert_equal(
-            asarray(from_view.layers[k]), asarray(modified.layers[k]), exact=True
-        )
+        assert_equal(from_view.layers[k], modified.layers[k], exact=True)
 
 
 def test_inplace_subset_obs(matrix_type, subset_func):
@@ -49,11 +47,9 @@ def test_inplace_subset_obs(matrix_type, subset_func):
     assert_equal(from_view.obs, modified.obs, exact=True)
     assert_equal(from_view.var, modified.var, exact=True)
     for k in from_view.obsm:
-        assert_equal(asarray(from_view.obsm[k]), asarray(modified.obsm[k]), exact=True)
+        assert_equal(from_view.obsm[k], modified.obsm[k], exact=True)
     for k in from_view.varm:
-        assert_equal(asarray(from_view.varm[k]), asarray(modified.varm[k]), exact=True)
-        assert_equal(asarray(orig.varm[k]), asarray(modified.varm[k]), exact=True)
+        assert_equal(from_view.varm[k], modified.varm[k], exact=True)
+        assert_equal(orig.varm[k], modified.varm[k], exact=True)
     for k in from_view.layers:
-        assert_equal(
-            asarray(from_view.layers[k]), asarray(modified.layers[k]), exact=True
-        )
+        assert_equal(from_view.layers[k], modified.layers[k], exact=True)

--- a/anndata/tests/test_io_elementwise.py
+++ b/anndata/tests/test_io_elementwise.py
@@ -57,6 +57,19 @@ def store(request):
         (pd.Categorical(list("aabccedd")), "categorical"),
         (pd.Categorical(list("aabccedd"), ordered=True), "categorical"),
         (pd.Categorical([1, 2, 1, 3], ordered=True), "categorical"),
+        (
+            pd.arrays.IntegerArray(
+                np.ones(5, dtype=int), mask=np.array([True, False, True, False, True])
+            ),
+            "nullable-integer",
+        ),
+        (
+            pd.arrays.BooleanArray(
+                np.random.randint(0, 2, size=5, dtype=bool),
+                mask=np.random.randint(0, 2, size=5, dtype=bool),
+            ),
+            "nullable-boolean",
+        ),
         # (bytes, b"some bytes", "bytes"), # Does not work for zarr
         # TODO consider how specific encodings should be. Should we be fully describing the written type?
         # Currently the info we add is: "what you wouldn't be able to figure out yourself"

--- a/anndata/tests/test_io_elementwise.py
+++ b/anndata/tests/test_io_elementwise.py
@@ -63,6 +63,7 @@ def store(request):
             ),
             "nullable-integer",
         ),
+        (pd.array([1, 2, 3]), "nullable-integer"),
         (
             pd.arrays.BooleanArray(
                 np.random.randint(0, 2, size=5, dtype=bool),
@@ -70,6 +71,7 @@ def store(request):
             ),
             "nullable-boolean",
         ),
+        (pd.array([True, False, True, True]), "nullable-boolean"),
         # (bytes, b"some bytes", "bytes"), # Does not work for zarr
         # TODO consider how specific encodings should be. Should we be fully describing the written type?
         # Currently the info we add is: "what you wouldn't be able to figure out yourself"

--- a/docs/fileformat-prose.rst
+++ b/docs/fileformat-prose.rst
@@ -180,3 +180,25 @@ Arrays of strings are handled differently than numeric arrays since numpy doesn'
 
 >>> dict(categorical["categories"].attrs)
 {'encoding-type': 'string-array', 'encoding-version': '0.2.0'}
+
+Nullable integers and booleans
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We support IO with Pandas nullable integer and boolean arrays.
+We represent these on disk similar to `numpy` masked arrays, `julia` nullable arrays, or `arrow` validity bitmaps (see :issue:`504` for more discussion).
+That is, we store a indicator array (or mask) of null values alongside the array of all values.
+
+>>> h5_file = h5py.File("anndata_format.h5", "a")
+>>> int_array = pd.array([1, None, 3, 4])
+>>> int_array
+<IntegerArray>
+[1, <NA>, 3, 4]
+Length: 4, dtype: Int64
+>>> write_elem(h5_file, "nullable_integer", int_array)
+
+>>> h5_file["nullable_integer"].visititems(print)
+mask <HDF5 dataset "mask": shape (4,), type "|b1">
+values <HDF5 dataset "values": shape (4,), type "<i8">
+
+>>> dict(h5_file["nullable_integer"].attrs)
+{'encoding-type': 'nullable-integer', 'encoding-version': '0.1.0'}


### PR DESCRIPTION
Fixes most of #504

* Adds support for reading and writing nullable ints and bools.
* Fixes merging dataframes with nullable ints and bools
  * Previously, boolean and integer series with null values would compare as unequal. They now compare as equal for the purposes of merging (i.e. `merge="unique"`, `merge="same"`)

TODO:

- [x] Docs
- [ ] Figure out how release notes will be done