### PR TITLE
Fix dtype of X changing when view copied

### DIFF
--- a/anndata/_core/anndata.py
+++ b/anndata/_core/anndata.py
@@ -1455,6 +1455,7 @@ class AnnData(metaclass=utils.DeprecationMixinMeta):
                 new[key] = getattr(self, key).copy()
         if "X" in kwargs:
             new["X"] = kwargs["X"]
+            new["dtype"] = new["X"].dtype
         elif self._has_X():
             new["X"] = self.X.copy()
             new["dtype"] = new["X"].dtype

--- a/anndata/tests/test_views.py
+++ b/anndata/tests/test_views.py
@@ -572,3 +572,9 @@ def test_view_mixin_copies_data(adata, array_type: type, attr):
 
         arr_view_copy[0, 0] = -5
         assert not np.array_equal(arr_view_copy, arr_view)
+
+
+def test_copy_X_dtype():
+    adata = ad.AnnData(sparse.eye(50, dtype=np.float64, format="csr"))
+    adata_c = adata[::2].copy()
+    assert adata_c.X.dtype == adata.X.dtype


### PR DESCRIPTION
Forgot to make sure the dtype carried through when copying a view