### PR TITLE
Import spmatrix from scipy.sparse

### DIFF
--- a/anndata/_core/merge.py
+++ b/anndata/_core/merge.py
@@ -13,7 +13,7 @@ from warnings import warn
 import numpy as np
 import pandas as pd
 from scipy import sparse
-from scipy.sparse.base import spmatrix
+from scipy.sparse import spmatrix
 
 from .anndata import AnnData
 from ..compat import Literal


### PR DESCRIPTION
Importing from `scipy.sparse.base` is deprecated since scipy 1.8.0.

`spmatrix` was always importable from `scipy.sparse`*, so that import location was probably just autocompletion

*I didn’t go farther back than https://github.com/scipy/scipy/commit/33e29d756153434d1c78f667c5b22f0a6413a956 from 2007, but it’s already been there then.